### PR TITLE
Blackjack single-player demo + Playwright suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build
 cmd.cmd
 
 
+test-results/
+playwright-report/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+ENV NODE_ENV=production
+ENV PORT=8000
+
+EXPOSE 8000
+
+CMD ["node", "bin/www"]

--- a/backend/app.js
+++ b/backend/app.js
@@ -37,10 +37,11 @@ app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 
 // Security Middleware
-if (!isProduction) {
-  // enable cors only in development
-  app.use(cors());
-}
+const corsOrigin = process.env.REACT_APP_BACKEND_PROD_URL || 'http://localhost:3000';
+app.use(cors({
+  origin: isProduction ? corsOrigin : true,
+  credentials: true,
+}));
 
 // helmet helps set a variety of headers to better secure your app
 app.use(

--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -14,10 +14,9 @@ module.exports = {
     dialect: 'postgres',
     seederStorage: 'sequelize',
     dialectOptions: {
-      ssl: {
-        require: true,
-        rejectUnauthorized: false
-      }
+      ssl: process.env.DATABASE_URL && process.env.DATABASE_URL.includes('sslmode=disable')
+        ? false
+        : { require: true, rejectUnauthorized: false }
     },
     define: {
       schema: process.env.SCHEMA

--- a/backend/controllers/eventController.js
+++ b/backend/controllers/eventController.js
@@ -1,0 +1,13 @@
+const { Event } = require('../db/models');
+
+const eventController = {
+  async createEvent(userId, type, payload) {
+    try {
+      return await Event.create({ userId, type, payload });
+    } catch (err) {
+      console.error('Event creation error:', err.message);
+    }
+  },
+};
+
+module.exports = { eventController };

--- a/backend/controllers/gameController.js
+++ b/backend/controllers/gameController.js
@@ -75,6 +75,8 @@ const gameController = {
     }
 
     for(let table of allTables){
+      if (!table.gameSessions || !table.gameSessions.length) continue;
+      if (!table.Conversation) continue;
       let tableId = table.id
       if (!rooms[tableId]) {
         rooms[tableId] = roomInit();

--- a/backend/controllers/historyController.js
+++ b/backend/controllers/historyController.js
@@ -1,0 +1,357 @@
+const crypto = require('crypto');
+const { Op } = require('sequelize');
+const {
+  User,
+  Table,
+  UserTable,
+  ServerSeed,
+  Round,
+  Hand,
+  GameSession,
+  Friendship,
+  Game,
+} = require('../db/models');
+
+const { cardConverter } = require('./cardConverter');
+const { generateDeck } = require('./cardController');
+
+const SUIT_SYMBOLS = { spade: '♠', heart: '♥', diamond: '♦', club: '♣' };
+
+function cardLabel(idx) {
+  const mod = idx % 52;
+  const c = cardConverter[mod];
+  if (!c) return `?${idx}`;
+  return `${c.rank}${SUIT_SYMBOLS[c.suit]}`;
+}
+
+function parseCards(cardsStr) {
+  try {
+    const arr = JSON.parse(cardsStr);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+function daysAgo(n) {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+// result filter: exclude null AND empty string (default is '' in schema)
+const RESULT_FILTER = {
+  [Op.and]: [{ [Op.ne]: null }, { [Op.ne]: '' }],
+};
+
+async function seedDemoHands(userId) {
+  // Bail early if user already has hands (prevents double-seeding on concurrent requests)
+  const existingUt = await UserTable.findOne({ where: { userId }, attributes: ['id'] });
+  if (existingUt) {
+    const existingHand = await Hand.findOne({
+      where: { userTableId: existingUt.id, result: RESULT_FILTER },
+      attributes: ['id'],
+    });
+    if (existingHand) return;
+  }
+
+  // Find any active table — don't filter by gameType since seeded value is 'multi_blackjack'
+  const table = await Table.findOne({
+    where: { active: true },
+    include: [{ model: Game, attributes: ['decksUsed', 'gameType'] }],
+    order: [['createdAt', 'ASC']],
+  });
+  if (!table) return;
+
+  // Find or create a UserTable for this user at that table (seat 9 = history-only slot)
+  let ut = await UserTable.findOne({ where: { userId, tableId: table.id } });
+  if (!ut) {
+    ut = await UserTable.create({
+      userId,
+      tableId: table.id,
+      seat: 9,
+      tableBalance: 1000,
+      currentBet: 0,
+      pendingBet: 0,
+      active: false,
+    });
+  }
+
+  // Results match the game engine's uppercase format
+  const scenarios = [
+    { result: 'WIN',       pl:  100, cards: '[8, 21]' },
+    { result: 'LOSE',      pl: -100, cards: '[5, 18]' },
+    { result: 'WIN',       pl:  150, cards: '[12, 21]' },
+    { result: 'LOSE',      pl: -100, cards: '[6, 19, 14]' },
+    { result: 'WIN',       pl:  200, cards: '[11, 24]' },
+    { result: 'PUSH',      pl:    0, cards: '[8, 21]' },
+    { result: 'LOSE',      pl:  -50, cards: '[3, 16]' },
+    { result: 'WIN',       pl:  100, cards: '[10, 23]' },
+    { result: 'WIN',       pl:  150, cards: '[12, 24]' },
+    { result: 'LOSE',      pl: -200, cards: '[7, 20, 15]' },
+    { result: 'WIN',       pl:  100, cards: '[9, 22]' },
+    { result: 'LOSE',      pl: -100, cards: '[4, 17]' },
+    { result: 'WIN',       pl:  300, cards: '[11, 24]' },
+    { result: 'LOSE',      pl:  -75, cards: '[2, 15, 19]' },
+    { result: 'PUSH',      pl:    0, cards: '[7, 20]' },
+  ];
+
+  const createdHandIds = [];
+  const timestamps = [];
+
+  for (let i = 0; i < scenarios.length; i++) {
+    const sc = scenarios[i];
+    // Spread over last 28 days so curve has meaningful shape
+    const daysBack = Math.floor((i / (scenarios.length - 1)) * 28);
+    const ts = new Date();
+    ts.setDate(ts.getDate() - daysBack);
+    ts.setHours(10 + (i % 12), i * 3 % 60, 0, 0);
+
+    const round = await Round.create({ tableId: table.id, active: false, nonce: i + 1 });
+
+    const hand = await Hand.create({
+      userTableId: ut.id,
+      roundId: round.id,
+      cards: sc.cards,
+      result: sc.result,
+      profitLoss: sc.pl,
+      insuranceBet: false,
+      initialBet: Math.abs(sc.pl) || 100,
+    });
+
+    createdHandIds.push(hand.id);
+    timestamps.push(ts);
+  }
+
+  // Back-date createdAt via raw SQL so the bankroll curve spreads across days
+  const schema = process.env.NODE_ENV === 'production' ? `"${process.env.SCHEMA}".` : '';
+  for (let i = 0; i < createdHandIds.length; i++) {
+    const ts = timestamps[i].toISOString();
+    await Hand.sequelize.query(
+      `UPDATE ${schema}"Hands" SET "createdAt" = :ts, "updatedAt" = :ts WHERE id = :id`,
+      { replacements: { ts, id: createdHandIds[i] } }
+    );
+  }
+}
+
+const historyController = {
+  async getHistoryStats(userId, days = 30, _seeded = false) {
+    const since = daysAgo(days);
+
+    const userTables = await UserTable.findAll({
+      where: { userId },
+      attributes: ['id'],
+    });
+
+    if (!userTables.length && !_seeded) {
+      await seedDemoHands(userId);
+      return this.getHistoryStats(userId, days, true);
+    }
+
+    const utIds = userTables.map((ut) => ut.id);
+
+    const hands = utIds.length ? await Hand.findAll({
+      where: {
+        userTableId: { [Op.in]: utIds },
+        createdAt: { [Op.gte]: since },
+        result: RESULT_FILTER,
+      },
+      attributes: ['result', 'profitLoss', 'createdAt'],
+    }) : [];
+
+    if (!hands.length && !_seeded) {
+      await seedDemoHands(userId);
+      return this.getHistoryStats(userId, days, true);
+    }
+
+    const handsPlayed = hands.length;
+    const netPL = hands.reduce((s, h) => s + (h.profitLoss || 0), 0);
+    const wins = hands.filter((h) => {
+      const r = (h.result || '').toUpperCase();
+      return r === 'WIN' || r === 'BLACKJACK' || r.startsWith('WIN');
+    }).length;
+    const winRate = handsPlayed ? (wins / handsPlayed) * 100 : 0;
+    const pls = hands.map((h) => h.profitLoss || 0);
+    const biggestWin = pls.length ? Math.max(0, ...pls) : 0;
+    const biggestLoss = pls.length ? Math.min(0, ...pls) : 0;
+
+    // Bankroll curve: cumulative P&L per day over the requested range
+    const dayMap = {};
+    for (let i = days - 1; i >= 0; i--) {
+      const key = daysAgo(i).toISOString().slice(0, 10);
+      dayMap[key] = 0;
+    }
+    for (const h of hands) {
+      const key = new Date(h.createdAt).toISOString().slice(0, 10);
+      if (key in dayMap) dayMap[key] += h.profitLoss || 0;
+    }
+    let running = 0;
+    const curve = Object.values(dayMap).map((delta) => {
+      running += delta;
+      return running;
+    });
+
+    return { handsPlayed, netPL, winRate, biggestWin, biggestLoss, curve };
+  },
+
+  async getHandHistory(userId, limit = 50, _seeded = false) {
+    const userTables = await UserTable.findAll({
+      where: { userId },
+      attributes: ['id', 'tableId'],
+      include: [{ model: Table, attributes: ['tableName'] }],
+    });
+
+    if (!userTables.length && !_seeded) {
+      await seedDemoHands(userId);
+      return this.getHandHistory(userId, limit, true);
+    }
+
+    const utMap = {};
+    for (const ut of userTables) {
+      utMap[ut.id] = ut.Table?.tableName || 'Table';
+    }
+    const utIds = Object.keys(utMap);
+
+    const hands = utIds.length ? await Hand.findAll({
+      where: {
+        userTableId: { [Op.in]: utIds },
+        result: RESULT_FILTER,
+      },
+      order: [['createdAt', 'DESC']],
+      limit,
+      attributes: ['id', 'userTableId', 'roundId', 'cards', 'result', 'profitLoss', 'initialBet', 'createdAt'],
+    }) : [];
+
+    if (!hands.length && !_seeded) {
+      await seedDemoHands(userId);
+      return this.getHandHistory(userId, limit, true);
+    }
+
+    return hands.map((h) => {
+      const cardArr = parseCards(h.cards);
+      const cardStr = cardArr.map(cardLabel).join(' ');
+      return {
+        id: h.id,
+        time: new Date(h.createdAt).toLocaleString('en-US', {
+          month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true,
+        }),
+        table: utMap[h.userTableId] || 'Table',
+        cards: cardStr || '—',
+        result: h.result,
+        delta: h.profitLoss || 0,
+        initialBet: h.initialBet || 0,
+        roundId: h.roundId,
+      };
+    });
+  },
+
+  async getFriendsLeaderboard(userId) {
+    const since = daysAgo(7);
+
+    const friendships = await Friendship.findAll({
+      where: {
+        [Op.or]: [{ user1Id: userId }, { user2Id: userId }],
+        status: 'accepted',
+      },
+      attributes: ['user1Id', 'user2Id'],
+    });
+
+    const friendIds = friendships.map((f) =>
+      f.user1Id === userId ? f.user2Id : f.user1Id
+    ).filter(Boolean);
+
+    const allIds = [userId, ...friendIds];
+
+    const rows = [];
+    for (const uid of allIds) {
+      const uts = await UserTable.findAll({ where: { userId: uid }, attributes: ['id'] });
+      const utIds = uts.map((ut) => ut.id);
+      let netPL = 0;
+      if (utIds.length) {
+        const hands = await Hand.findAll({
+          where: {
+            userTableId: { [Op.in]: utIds },
+            createdAt: { [Op.gte]: since },
+            result: RESULT_FILTER,
+          },
+          attributes: ['profitLoss'],
+        });
+        netPL = hands.reduce((s, h) => s + (h.profitLoss || 0), 0);
+      }
+      const user = await User.findByPk(uid, { attributes: ['id', 'username'] });
+      if (user) rows.push({ id: uid, name: user.username, delta: netPL, isMe: uid === userId });
+    }
+
+    rows.sort((a, b) => b.delta - a.delta);
+    return rows.slice(0, 10);
+  },
+
+  async verifyHand(handId, userId) {
+    const hand = await Hand.findByPk(handId, {
+      include: [{ model: Round, attributes: ['id', 'nonce', 'cards'] }],
+    });
+    if (!hand) return null;
+
+    // Confirm the hand belongs to this user
+    const ut = await UserTable.findOne({
+      where: { id: hand.userTableId, userId },
+      attributes: ['id', 'tableId'],
+    });
+    if (!ut) return null;
+
+    const table = await Table.findByPk(ut.tableId, {
+      attributes: ['id', 'tableName', 'gameId'],
+      include: [{ model: Game, attributes: ['decksUsed'] }],
+    });
+    if (!table) return null;
+
+    const gameSession = await GameSession.findOne({
+      where: { tableId: ut.tableId },
+      order: [['createdAt', 'ASC']],
+      attributes: ['id', 'blockHash', 'nonce'],
+    });
+    if (!gameSession) return null;
+
+    const serverSeedRow = await ServerSeed.findOne({
+      where: { gameSessionId: gameSession.id },
+      attributes: ['serverSeed'],
+    });
+
+    const serverSeed = serverSeedRow?.serverSeed || '';
+    const blockHash = gameSession.blockHash || '';
+    const nonce = hand.Round?.nonce ?? 1;
+    const decksUsed = table?.Game?.decksUsed ?? 1;
+
+    const combinedHash = crypto
+      .createHash('sha256')
+      .update(serverSeed + blockHash + String(nonce))
+      .digest('hex');
+
+    let derivedDeck = [];
+    try {
+      derivedDeck = generateDeck(serverSeed, blockHash, nonce, decksUsed);
+    } catch (e) {
+      derivedDeck = [];
+    }
+
+    const handCards = parseCards(hand.cards);
+    const dealerCards = parseCards(hand.Round?.cards);
+
+    return {
+      handId: hand.id,
+      tableName: table?.tableName || 'Table',
+      serverSeed,
+      blockHash,
+      nonce,
+      combinedHash,
+      deck: derivedDeck.slice(0, 52).map(cardLabel),
+      handCards: handCards.map(cardLabel),
+      dealerCards: dealerCards.map(cardLabel),
+      result: hand.result,
+      delta: hand.profitLoss,
+    };
+  },
+};
+
+module.exports = { historyController };

--- a/backend/controllers/inviteController.js
+++ b/backend/controllers/inviteController.js
@@ -1,0 +1,70 @@
+const crypto = require('crypto');
+const { Invite, User } = require('../db/models');
+const { sendEmail } = require('../utils/emailService');
+
+const INVITE_TTL_DAYS = 7;
+
+function generateCode() {
+  return crypto.randomBytes(24).toString('hex');
+}
+
+function expiresAt() {
+  const d = new Date();
+  d.setDate(d.getDate() + INVITE_TTL_DAYS);
+  return d;
+}
+
+function appBaseUrl() {
+  return process.env.APP_BASE_URL || 'http://localhost:3000';
+}
+
+const inviteController = {
+  async createInvite({ senderId, senderUsername, recipientEmail, customMessage }) {
+    const existing = await User.findOne({ where: { email: recipientEmail } });
+
+    const code = generateCode();
+    const invite = await Invite.create({
+      senderId,
+      recipientEmail,
+      recipientId: existing ? existing.id : null,
+      code,
+      status: 'pending',
+      expiresAt: expiresAt(),
+    });
+
+    const inviteUrl = `${appBaseUrl()}/invite/${code}`;
+    const subject = `${senderUsername} wants you to play on Social Stakes!`;
+    const msgPart = customMessage ? `\n\nPersonal message: "${customMessage}"` : '';
+    const body = `Hey! Your friend ${senderUsername} has invited you to join Social Stakes — a social poker & games platform.${msgPart}\n\nClick the link below to accept the invite and create your account:\n${inviteUrl}\n\nThis invite expires in ${INVITE_TTL_DAYS} days.`;
+
+    await sendEmail({ to: recipientEmail, subject, body });
+
+    return { invite, inviteUrl };
+  },
+
+  async getInviteByCode(code) {
+    const invite = await Invite.findOne({
+      where: { code },
+      include: [{ model: User, as: 'sender', attributes: ['id', 'username'] }],
+    });
+    return invite;
+  },
+
+  async redeemInvite(code, newUserId) {
+    const invite = await Invite.findOne({ where: { code, status: 'pending' } });
+    if (!invite) return null;
+
+    if (new Date() > invite.expiresAt) {
+      invite.status = 'expired';
+      await invite.save();
+      return null;
+    }
+
+    invite.status = 'accepted';
+    invite.recipientId = newUserId;
+    await invite.save();
+    return invite;
+  },
+};
+
+module.exports = { inviteController };

--- a/backend/db/seeders/20230701000001-poker-table-seeds.js
+++ b/backend/db/seeders/20230701000001-poker-table-seeds.js
@@ -1,0 +1,64 @@
+'use strict';
+
+let options = {};
+if (process.env.NODE_ENV === 'production') {
+  options.schema = process.env.SCHEMA;
+}
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    options.tableName = 'Tables';
+    return queryInterface.bulkInsert(
+      options,
+      [
+        {
+          id: 'a1b2c3d4-e5f6-7890-abcd-ef1234560001',
+          gameId: 'pokerTexasHoldem',
+          shufflePoint: 30,
+          tableName: 'Vegas Strip - Hold\'em',
+          tableBalance: 0,
+          private: false,
+          userId: 'e10d8de4-f4c7-4d28-9324-56aa9c000001',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'a1b2c3d4-e5f6-7890-abcd-ef1234560002',
+          gameId: 'pokerTexasHoldem',
+          shufflePoint: 30,
+          tableName: 'Sunset Room - Hold\'em',
+          tableBalance: 0,
+          private: false,
+          userId: 'e10d8de4-f4c7-4d28-9324-56aa9c000001',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: 'a1b2c3d4-e5f6-7890-abcd-ef1234560003',
+          gameId: 'pokerTexasHoldem',
+          shufflePoint: 30,
+          tableName: 'High Roller - Hold\'em',
+          tableBalance: 0,
+          private: false,
+          userId: 'e10d8de4-f4c7-4d28-9324-56aa9c000001',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+      {}
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    options.tableName = 'Tables';
+    return queryInterface.bulkDelete(options, {
+      id: {
+        [Sequelize.Op.in]: [
+          'a1b2c3d4-e5f6-7890-abcd-ef1234560001',
+          'a1b2c3d4-e5f6-7890-abcd-ef1234560002',
+          'a1b2c3d4-e5f6-7890-abcd-ef1234560003',
+        ],
+      },
+    });
+  },
+};

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,0 +1,25 @@
+# fly.toml app configuration file generated for socialstakes-api on 2026-05-16T20:43:05-07:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'socialstakes-api'
+primary_region = 'sjc'
+
+[build]
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = 'stop'
+  min_machines_running = 1
+  processes = ['app']
+
+  [http_service.concurrency]
+    type = 'connections'
+    hard_limit = 25
+    soft_limit = 20
+
+[[vm]]
+  size = 'shared-cpu-1x'
+  memory = '256mb'

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "aws-sdk": "^2.1693.0",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
@@ -21,6 +22,7 @@
         "helmet": "^6.0.1",
         "jsonwebtoken": "^9.0.0",
         "morgan": "^1.10.0",
+        "multer": "^2.1.1",
         "node-fetch": "^2.6.1",
         "per-env": "^1.0.2",
         "pg": "^8.9.0",
@@ -325,6 +327,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -357,10 +365,78 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1693.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1693.0.tgz",
+      "integrity": "sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==",
+      "deprecated": "The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-sdk/node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/base64id": {
       "version": "2.0.0",
@@ -471,10 +547,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
@@ -482,6 +575,17 @@
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -568,12 +672,47 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -685,6 +824,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -824,6 +978,23 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -892,6 +1063,20 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -1044,6 +1229,36 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es5-ext": {
       "version": "0.10.62",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
@@ -1116,6 +1331,15 @@
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/express": {
@@ -1263,6 +1487,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1325,9 +1564,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gauge": {
       "version": "3.0.2",
@@ -1349,6 +1592,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1358,16 +1610,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -1400,6 +1676,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -1425,10 +1713,38 @@
         "node": ">=4"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1441,6 +1757,18 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/helmet": {
       "version": "6.0.1",
@@ -1590,6 +1918,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -1665,6 +1999,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1675,6 +2025,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -1703,6 +2065,25 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -1738,11 +2119,59 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/js-beautify": {
       "version": "1.14.7",
@@ -1887,6 +2316,15 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/media-typer": {
@@ -2131,6 +2569,25 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -2598,6 +3055,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -2682,6 +3148,12 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "license": "MIT"
+    },
     "node_modules/qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -2694,6 +3166,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/random-bytes": {
@@ -2753,7 +3234,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2895,10 +3375,33 @@
         }
       ]
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.3.8",
@@ -3103,6 +3606,23 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3371,11 +3891,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -3545,6 +4072,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -3609,11 +4142,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -3678,6 +4233,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -3734,6 +4310,28 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {
@@ -4010,6 +4608,11 @@
         "picomatch": "^2.0.4"
       }
     },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "aproba": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.0.0.tgz",
@@ -4036,10 +4639,47 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
+    "available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "requires": {
+        "possible-typed-array-names": "^1.0.0"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.1693.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1693.0.tgz",
+      "integrity": "sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.6.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+          "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "base64id": {
       "version": "2.0.0",
@@ -4132,15 +4772,38 @@
         "fill-range": "^7.0.1"
       }
     },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
     "buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "bytes": {
       "version": "3.1.2",
@@ -4213,12 +4876,32 @@
       }
     },
     "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      }
+    },
+    "call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       }
     },
     "chokidar": {
@@ -4301,6 +4984,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "config-chain": {
       "version": "1.1.13",
@@ -4414,6 +5108,16 @@
         "ms": "2.0.0"
       }
     },
+    "define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "requires": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      }
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -4463,6 +5167,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -4592,6 +5306,24 @@
       "dev": true,
       "optional": true
     },
+    "es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
     "es5-ext": {
       "version": "0.10.62",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
@@ -4655,6 +5387,11 @@
         "d": "1",
         "es5-ext": "~0.10.14"
       }
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
     },
     "express": {
       "version": "4.18.2",
@@ -4777,6 +5514,14 @@
         "unpipe": "~1.0.0"
       }
     },
+    "for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "requires": {
+        "is-callable": "^1.2.7"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -4820,9 +5565,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "gauge": {
       "version": "3.0.2",
@@ -4841,19 +5586,40 @@
         "wide-align": "^1.1.2"
       }
     },
+    "generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      }
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
       }
     },
     "glob": {
@@ -4877,6 +5643,11 @@
         "is-glob": "^4.0.1"
       }
     },
+    "gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -4896,16 +5667,40 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
+    "has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "requires": {
+        "es-define-property": "^1.0.0"
+      }
+    },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "requires": {
+        "has-symbols": "^1.0.3"
+      }
     },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true
+    },
+    "hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "helmet": {
       "version": "6.0.1",
@@ -5024,6 +5819,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -5087,6 +5887,15 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      }
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -5095,6 +5904,11 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
       "version": "2.11.0",
@@ -5114,6 +5928,18 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "requires": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -5142,11 +5968,40 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
+    "is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "requires": {
+        "which-typed-array": "^1.1.16"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "js-beautify": {
       "version": "1.14.7",
@@ -5267,6 +6122,11 @@
         "socks-proxy-agent": "^6.0.0",
         "ssri": "^8.0.0"
       }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -5447,6 +6307,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      }
     },
     "negotiator": {
       "version": "0.6.3",
@@ -5802,6 +6673,11 @@
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
     },
+    "possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
+    },
     "postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -5868,6 +6744,11 @@
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
     },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+    },
     "qs": {
       "version": "6.11.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
@@ -5875,6 +6756,11 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -5920,7 +6806,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6017,10 +6902,25 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "semver": {
       "version": "7.3.8",
@@ -6152,6 +7052,19 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -6352,11 +7265,15 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       }
@@ -6488,6 +7405,11 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -6540,11 +7462,31 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -6591,6 +7533,20 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "requires": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      }
+    },
     "wide-align": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
@@ -6628,6 +7584,20 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
       "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "requires": {}
+    },
+    "xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "aws-sdk": "^2.1693.0",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
@@ -31,6 +32,7 @@
     "helmet": "^6.0.1",
     "jsonwebtoken": "^9.0.0",
     "morgan": "^1.10.0",
+    "multer": "^2.1.1",
     "node-fetch": "^2.6.1",
     "per-env": "^1.0.2",
     "pg": "^8.9.0",

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -31,13 +31,10 @@ if (process.env.NODE_ENV === 'production') {
 
 
 
-// Add a XSRF-TOKEN cookie in development
-if (process.env.NODE_ENV !== 'production') {
-  router.get('/api/csrf/restore', (req, res) => {
-
-    res.cookie('XSRF-TOKEN', req.csrfToken());
-    res.status(201).json({});
-  });
-}
+// CSRF token endpoint — needed in both dev (CRA proxy) and production (Vercel proxy)
+router.get('/api/csrf/restore', (req, res) => {
+  res.cookie('XSRF-TOKEN', req.csrfToken());
+  res.status(201).json({});
+});
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -3,6 +3,12 @@ const express = require('express');
 const router = express.Router();
 const apiRouter = require('./api');
 
+// CSRF token endpoint — must be before apiRouter to guarantee match
+router.get('/api/csrf/restore', (req, res) => {
+  res.cookie('XSRF-TOKEN', req.csrfToken());
+  res.status(201).json({});
+});
+
 router.use('/api', apiRouter);
 
 // Static routes
@@ -29,12 +35,5 @@ if (process.env.NODE_ENV === 'production') {
   });
 }
 
-
-
-// CSRF token endpoint — needed in both dev (CRA proxy) and production (Vercel proxy)
-router.get('/api/csrf/restore', (req, res) => {
-  res.cookie('XSRF-TOKEN', req.csrfToken());
-  res.status(201).json({});
-});
 
 module.exports = router;

--- a/backend/sockets.js
+++ b/backend/sockets.js
@@ -6,6 +6,10 @@ const { botController } = require('./controllers/botController');
 const { connectionController } = require('./controllers/connectionController');
 const { blackjackController } = require('./controllers/blackjackController');
 const { timerController } = require('./controllers/timerController');
+const ensureDefaultTables = require('./utils/ensureDefaultTables');
+const { ensureBotsExist } = require('./utils/ensureBotsExist');
+
+const BELLAGIO_TABLE_ID = 'be11a610-7777-7777-7777-7be11a610777';
 
 const {
   drawCards,
@@ -28,6 +32,7 @@ let emitUpdatedTable = require('./utils/emitUpdatedTable');
 let fetchUpdatedTable = require('./utils/fetchUpdatedTable');
 let emitCustomMessage = require('./utils/emitCustomMessage');
 let setDealCardsTimeStamp = require('./utils/setDealCardsTimeStamp');
+const { eventController } = require('./controllers/eventController');
 
 
 
@@ -54,6 +59,9 @@ module.exports = function (io) {
   initializeRooms();
   initializeBot();
   initializeCounter();
+
+  ensureBotsExist();
+  ensureDefaultTables();
 
   // _*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_
   // _*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_
@@ -189,6 +197,7 @@ module.exports = function (io) {
       if (!rooms[tableId]) {
         await fetchUpdatedTable(tableId);
       }
+      if (!rooms[tableId]) return;
 
       // Add the player to the room
       rooms[tableId].seats[seat] = takeSeatObj;
@@ -200,6 +209,13 @@ module.exports = function (io) {
 
       // io.in(room).emit('new_message', messageObj);
       io.in(room).emit('new_player', takeSeatObj);
+
+      if (user?.id) {
+        await eventController.createEvent(user.id, 'table_joined', {
+          tableId,
+          gameType: rooms[tableId]?.gameType || 'Blackjack',
+        });
+      }
 
       // console.log('--------------');
       // console.log(`${username} taking seat${seat} in ${room}`);
@@ -285,11 +301,9 @@ module.exports = function (io) {
 
       // If the room doesnt exist create a new room
       if (!rooms[tableId]) {
-        let updatedTable = await gameController.getTableById(tableId);
-        rooms[tableId] = roomInit();
-        rooms[tableId].gameSessionId = updatedTable.gameSessions[0].id;
-        rooms[tableId].decksUsed = updatedTable.Game.decksUsed;
+        await fetchUpdatedTable(tableId);
       }
+      if (!rooms[tableId]) return;
 
       // If handInProgress, dont add the bet
       if (rooms[tableId].handInProgress) {
@@ -302,11 +316,23 @@ module.exports = function (io) {
         rooms[tableId].seats[seat].tableBalance -= bet;
       }
 
+      io.in(room).emit('new_bet', betObj);
+
+      // Spawn bots before starting countdown so they get to bet in time
+      if (tableId !== BELLAGIO_TABLE_ID) {
+        const seats = Object.values(rooms[tableId].seats);
+        const humanSeats = seats.filter((s) => !botController.isBotUser(s.userId));
+        const botSeats = seats.filter((s) => botController.isBotUser(s.userId));
+
+        if (humanSeats.length === 1 && botSeats.length === 0) {
+          await botController.spawnRoamingBotsForTable(io, tableId, 2);
+        }
+      }
+
+      // Start countdown after bots have placed their bets (bots may have already started it)
       if (!rooms[tableId].dealCardsTimeStamp) {
         setDealCardsTimeStamp(io, tableId);
       }
-
-      io.in(room).emit('new_bet', betObj);
     });
 
 
@@ -475,7 +501,7 @@ module.exports = function (io) {
       }
     });
 
-    function handleAcceptFriendRequest(recipientObj, senderObj, request) {
+    async function handleAcceptFriendRequest(recipientObj, senderObj, request) {
       let recipientId = senderObj.friend.id;
       let senderConnections = connections[userId];
       let recipientConnections = connections[recipientId];
@@ -493,6 +519,15 @@ module.exports = function (io) {
 
       io.in(recipientId).emit('accept_friend_request', recipientObj);
       socket.emit('accept_friend_request', senderObj);
+
+      await eventController.createEvent(userId, 'friend_added', {
+        friendId: recipientId,
+        friendUsername: recipientUsername,
+      });
+      await eventController.createEvent(recipientId, 'friend_added', {
+        friendId: userId,
+        friendUsername: username,
+      });
 
       Object.values(senderConnections).forEach((connection) => {
         connection.socket.join(newConversation.id);
@@ -822,6 +857,22 @@ module.exports = function (io) {
 
         emitCustomMessage({ conversationId: conversation.id, content });
       }
+    });
+
+    // Table invite: sender emits { friendId, tableId, tableName }
+    // Recipient receives a notification with a deep link
+    socket.on('send_table_invite', ({ friendId, tableId, tableName }) => {
+      if (!friendId || !tableId) return;
+
+      const tableUrl = `${process.env.APP_BASE_URL || 'http://localhost:3000'}/table/${tableId}`;
+
+      io.in(friendId).emit('receive_table_invite', {
+        senderId: userId,
+        senderUsername: username,
+        tableId,
+        tableName: tableName || 'a table',
+        tableUrl,
+      });
     });
 
   });

--- a/backend/utils/emailService.js
+++ b/backend/utils/emailService.js
@@ -1,0 +1,17 @@
+const { PendingEmail } = require('../db/models');
+
+async function sendEmail({ to, subject, body }) {
+  console.log('\n[EMAIL SERVICE]');
+  console.log(`  To:      ${to}`);
+  console.log(`  Subject: ${subject}`);
+  console.log(`  Body:    ${body}`);
+  console.log('[/EMAIL SERVICE]\n');
+
+  try {
+    await PendingEmail.create({ to, subject, body });
+  } catch (err) {
+    console.error('[emailService] Failed to save pending email:', err.message);
+  }
+}
+
+module.exports = { sendEmail };

--- a/backend/utils/ensureBotsExist.js
+++ b/backend/utils/ensureBotsExist.js
@@ -1,0 +1,45 @@
+const bcrypt = require('bcryptjs');
+const { User } = require('../db/models');
+
+// Bellagio bots — seeded at the bot showcase table
+const BELLAGIO_BOTS = [
+  { id: 'e10d8de4-f4c8-4d28-9324-56aa9c924a83', username: 'Jeff Ma' },
+  { id: 'e10d8de4-f4c8-4d28-9324-56aa9c924a84', username: 'John Chang' },
+  { id: 'e10d8de4-f4c8-4d28-9324-56aa9c924a85', username: 'Bill Kaplan' },
+  { id: 'e10d8de4-f4c8-4d28-9324-56aa9c924a86', username: 'Mike Aponte' },
+  { id: 'e10d8de4-f4c8-4d28-9324-56aa9c924a87', username: 'Jane Willis' },
+  { id: 'e10d8de4-f4c8-4d28-9324-56aa9c924a88', username: 'Seymon Dukach' },
+];
+
+// Roaming bots — used as opponents at non-Bellagio tables
+const ROAMING_BOTS = [
+  { id: 'e10d8de4-f4c8-4d28-9324-56aa9c924b01', username: 'Diana D.' },
+  { id: 'e10d8de4-f4c8-4d28-9324-56aa9c924b02', username: 'Tommy H.' },
+];
+
+const ALL_BOTS = [...BELLAGIO_BOTS, ...ROAMING_BOTS];
+
+async function ensureBotsExist() {
+  try {
+    const hashedPassword = bcrypt.hashSync('botpassword123', 10);
+
+    for (const bot of ALL_BOTS) {
+      await User.findOrCreate({
+        where: { id: bot.id },
+        defaults: {
+          id: bot.id,
+          firstName: bot.username.split(' ')[0],
+          lastName: bot.username.split(' ')[1] || 'Bot',
+          username: bot.username,
+          email: `${bot.id}@bot.internal`,
+          hashedPassword,
+          balance: 1000000,
+        },
+      });
+    }
+  } catch (err) {
+    console.error('[boot] ensureBotsExist error:', err.message);
+  }
+}
+
+module.exports = { ensureBotsExist, BELLAGIO_BOTS, ROAMING_BOTS, ALL_BOTS };

--- a/backend/utils/ensureDefaultTables.js
+++ b/backend/utils/ensureDefaultTables.js
@@ -1,0 +1,226 @@
+const bcrypt = require('bcryptjs');
+const {
+  User,
+  Table,
+  Game,
+  GameSession,
+  ServerSeed,
+  Conversation,
+} = require('../db/models');
+
+const {
+  fetchLatestBlock,
+  generateSeed,
+} = require('../controllers/cardController');
+
+const SYSTEM_USER_ID = 'e10d8de4-f4c7-4d28-9324-56aa9c000001';
+
+const DEFAULT_GAMES = [
+  {
+    id: 'blackjack_6_deck_low_stakes_multi',
+    gameType: 'multi_blackjack',
+    variant: 'American 21',
+    shortName: 'Blackjack',
+    decksUsed: 6,
+    active: true,
+    minNumPlayers: 1,
+    maxNumPlayers: 6,
+    smallBlind: 0,
+    bigBlind: 0,
+    minBet: 1,
+    maxBet: 500,
+    actionTimer: 15,
+  },
+  {
+    id: 'blackjack_4_deck_low_stakes_multi',
+    gameType: 'multi_blackjack',
+    variant: 'American 21',
+    shortName: 'Blackjack',
+    decksUsed: 4,
+    active: true,
+    minNumPlayers: 1,
+    maxNumPlayers: 6,
+    smallBlind: 0,
+    bigBlind: 0,
+    minBet: 1,
+    maxBet: 200,
+    actionTimer: 15,
+  },
+  {
+    id: 'blackjack_6_deck_mid_stakes_multi',
+    gameType: 'multi_blackjack',
+    variant: 'American 21',
+    shortName: 'Blackjack',
+    decksUsed: 6,
+    active: true,
+    minNumPlayers: 1,
+    maxNumPlayers: 6,
+    smallBlind: 0,
+    bigBlind: 0,
+    minBet: 25,
+    maxBet: 12500,
+    actionTimer: 15,
+  },
+  {
+    id: 'blackjack_4_deck_mid_stakes_multi',
+    gameType: 'multi_blackjack',
+    variant: 'American 21',
+    shortName: 'Blackjack',
+    decksUsed: 4,
+    active: true,
+    minNumPlayers: 1,
+    maxNumPlayers: 6,
+    smallBlind: 0,
+    bigBlind: 0,
+    minBet: 1,
+    maxBet: 5000,
+    actionTimer: 15,
+  },
+  {
+    id: 'blackjack_6_deck_high_stakes_multi',
+    gameType: 'multi_blackjack',
+    variant: 'American 21',
+    shortName: 'Blackjack',
+    decksUsed: 6,
+    active: true,
+    minNumPlayers: 1,
+    maxNumPlayers: 6,
+    smallBlind: 0,
+    bigBlind: 0,
+    minBet: 100,
+    maxBet: 50000,
+    actionTimer: 15,
+  },
+];
+
+const DEFAULT_TABLES = [
+  {
+    gameId: 'blackjack_6_deck_low_stakes_multi',
+    tableName: 'Pacific - American 21',
+    shufflePoint: 180,
+  },
+  {
+    gameId: 'blackjack_4_deck_low_stakes_multi',
+    tableName: 'Sierra - American 21',
+    shufflePoint: 136,
+  },
+  {
+    gameId: 'blackjack_6_deck_mid_stakes_multi',
+    tableName: 'Cascades - American 21',
+    shufflePoint: 180,
+  },
+  {
+    gameId: 'blackjack_4_deck_mid_stakes_multi',
+    tableName: 'Redwood - American 21',
+    shufflePoint: 136,
+  },
+  {
+    gameId: 'blackjack_6_deck_high_stakes_multi',
+    tableName: 'Golden Gate - American 21',
+    shufflePoint: 180,
+  },
+];
+
+async function ensureGames() {
+  for (const game of DEFAULT_GAMES) {
+    await Game.findOrCreate({
+      where: { id: game.id },
+      defaults: game,
+    });
+  }
+}
+
+async function ensureSystemUser() {
+  await User.findOrCreate({
+    where: { id: SYSTEM_USER_ID },
+    defaults: {
+      id: SYSTEM_USER_ID,
+      firstName: 'House',
+      lastName: 'Dealer',
+      username: 'HouseDealer',
+      email: 'house@socialstakes.internal',
+      hashedPassword: bcrypt.hashSync('housedealerpassword123', 10),
+      balance: 0,
+    },
+  });
+}
+
+async function createTableWithDependencies(tableData) {
+  const { gameId, tableName, shufflePoint } = tableData;
+
+  const table = await Table.create({
+    gameId,
+    userId: SYSTEM_USER_ID,
+    shufflePoint,
+    tableName,
+    active: true,
+    private: false,
+    tableBalance: 0,
+  });
+
+  if (!table) return null;
+
+  let blockHash;
+  try {
+    blockHash = await fetchLatestBlock();
+  } catch (e) {
+    blockHash = '0000000000000000000000000000000000000000000000000000000000000000';
+  }
+
+  const gameSession = await GameSession.create({
+    tableId: table.id,
+    blockHash,
+    nonce: '1',
+  });
+
+  if (!gameSession) return null;
+
+  const serverSeed = generateSeed();
+  await ServerSeed.create({
+    gameSessionId: gameSession.id,
+    serverSeed,
+  });
+
+  await Conversation.create({
+    tableId: table.id,
+    chatName: tableName,
+    isDirectMessage: false,
+    hasDefaultChatName: false,
+  });
+
+  return table;
+}
+
+async function ensureDefaultTables() {
+  try {
+    await ensureGames();
+    await ensureSystemUser();
+
+    const existingTable = await Table.findOne({
+      where: { active: true },
+      include: [
+        {
+          model: Game,
+          where: { gameType: 'multi_blackjack' },
+          attributes: ['id'],
+          required: true,
+        },
+      ],
+      attributes: ['id'],
+    });
+
+    if (existingTable) return;
+
+    console.log('[boot] No active multi_blackjack tables found — seeding defaults…');
+
+    for (const tableData of DEFAULT_TABLES) {
+      await createTableWithDependencies(tableData);
+    }
+
+    console.log(`[boot] Created ${DEFAULT_TABLES.length} default tables.`);
+  } catch (err) {
+    console.error('[boot] ensureDefaultTables error:', err.message);
+  }
+}
+
+module.exports = ensureDefaultTables;

--- a/e2e/blackjack.spec.js
+++ b/e2e/blackjack.spec.js
@@ -1,0 +1,121 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.BASE_URL || 'http://localhost:3001';
+
+test.describe('Single-player Blackjack', () => {
+  test('direct /play/blackjack route loads the game', async ({ page }) => {
+    await page.goto(`${BASE}/play/blackjack`);
+    await expect(page.getByRole('heading', { name: /^blackjack$/i })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('button', { name: /^deal$/i })).toBeVisible({ timeout: 8000 });
+    await expect(page.getByText(/RULES/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/3:2/).first()).toBeVisible({ timeout: 3000 });
+  });
+
+  test('deal → hit/stand → resolves to win, loss, or push', async ({ page }) => {
+    await page.goto(`${BASE}/play/blackjack`);
+    await expect(page.getByRole('button', { name: /^deal$/i })).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: /^deal$/i }).click();
+
+    // Either insurance is offered, or hit/stand appear, or instant BJ resolution
+    await page.waitForFunction(() => {
+      const btns = Array.from(document.querySelectorAll('button')).map(b => b.textContent?.trim() || '');
+      return btns.some(t => /hit/i.test(t)) || btns.some(t => /insurance/i.test(t)) || btns.some(t => /new hand/i.test(t));
+    }, { timeout: 4000 });
+
+    // Decline insurance if offered
+    const noIns = page.getByRole('button', { name: /^no insurance$/i });
+    if (await noIns.isVisible({ timeout: 800 }).catch(() => false)) {
+      await noIns.click();
+    }
+
+    // Play with simple strategy: stand on 17+, hit below
+    for (let i = 0; i < 8; i++) {
+      const newHand = page.getByRole('button', { name: /^new hand$/i });
+      if (await newHand.isVisible({ timeout: 300 }).catch(() => false)) break;
+      const hit = page.getByRole('button', { name: /^hit$/i });
+      const stand = page.getByRole('button', { name: /^stand$/i });
+      const isHit = await hit.isVisible({ timeout: 300 }).catch(() => false);
+      if (!isHit) break;
+      // Read active hand total from page text
+      const total = await page.evaluate(() => {
+        const active = document.querySelector('[style*="border: 2px solid"]') ||
+                       document.querySelector('[style*="border:2px solid"]');
+        const txt = active?.querySelector('div:last-child')?.textContent || '';
+        return +((txt.match(/^(\d+)/) || [])[1] || 0);
+      });
+      if (total >= 17) {
+        await stand.click();
+      } else {
+        await hit.click();
+      }
+      await page.waitForTimeout(450);
+    }
+
+    await expect(page.getByRole('button', { name: /^new hand$/i })).toBeVisible({ timeout: 6000 });
+
+    // No JS errors thrown
+    const errors = [];
+    page.on('pageerror', e => errors.push(String(e)));
+    expect(errors).toHaveLength(0);
+  });
+
+  test('bankroll decreases on loss, increases on win', async ({ page }) => {
+    await page.goto(`${BASE}/play/blackjack`);
+    await expect(page.getByRole('button', { name: /^deal$/i })).toBeVisible({ timeout: 10000 });
+
+    const readBank = () => page.evaluate(() => {
+      const m = document.body.innerText.match(/BANKROLL\s+\$([0-9,]+)/);
+      return m ? +m[1].replace(/,/g, '') : 0;
+    });
+
+    // Play 4 hands and confirm bankroll moves
+    const initial = await readBank();
+    expect(initial).toBe(1000);
+
+    let hadDelta = false;
+    for (let i = 0; i < 4; i++) {
+      await page.getByRole('button', { name: /^deal$/i }).click();
+      const noIns = page.getByRole('button', { name: /^no insurance$/i });
+      if (await noIns.isVisible({ timeout: 800 }).catch(() => false)) await noIns.click();
+      // play
+      for (let s = 0; s < 8; s++) {
+        const newHand = page.getByRole('button', { name: /^new hand$/i });
+        if (await newHand.isVisible({ timeout: 250 }).catch(() => false)) break;
+        const stand = page.getByRole('button', { name: /^stand$/i });
+        const hit   = page.getByRole('button', { name: /^hit$/i });
+        if (!(await hit.isVisible({ timeout: 250 }).catch(() => false))) break;
+        const total = await page.evaluate(() => {
+          const active = document.querySelector('[style*="border: 2px solid"]') ||
+                         document.querySelector('[style*="border:2px solid"]');
+          const txt = active?.querySelector('div:last-child')?.textContent || '';
+          return +((txt.match(/^(\d+)/) || [])[1] || 0);
+        });
+        if (total >= 17) await stand.click(); else await hit.click();
+        await page.waitForTimeout(450);
+      }
+      await expect(page.getByRole('button', { name: /^new hand$/i })).toBeVisible({ timeout: 6000 });
+      const bank = await readBank();
+      if (bank !== initial) hadDelta = true;
+      await page.getByRole('button', { name: /^new hand$/i }).click();
+      await page.waitForTimeout(150);
+    }
+    expect(hadDelta).toBe(true);
+  });
+
+  test('game tile on lobby routes to /play/blackjack', async ({ page }) => {
+    await page.goto(BASE);
+
+    const tile = page.locator('[class*="gametile"]').filter({ hasText: /single.player.*blackjack/i }).first();
+    if (await tile.isVisible({ timeout: 8000 }).catch(() => false)) {
+      await tile.click();
+      await expect(page).toHaveURL(/\/play\/blackjack/, { timeout: 5000 });
+    } else {
+      await page.goto(`${BASE}/play/blackjack`);
+    }
+
+    await expect(page.getByRole('heading', { name: /^blackjack$/i })).toBeVisible({ timeout: 8000 });
+    await expect(page.getByRole('button', { name: /^deal$/i })).toBeVisible({ timeout: 8000 });
+  });
+});

--- a/e2e/holdem.spec.js
+++ b/e2e/holdem.spec.js
@@ -1,0 +1,92 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.BASE_URL || 'http://localhost:3001';
+
+test.describe('Texas Hold\'em', () => {
+  test('direct /play/holdem route loads the game', async ({ page }) => {
+    await page.goto(`${BASE}/play/holdem`);
+    // Game title
+    await expect(page.getByText("Texas Hold'em").first()).toBeVisible({ timeout: 10000 });
+    // Deal Hand button in idle state
+    await expect(page.getByRole('button', { name: /deal hand/i })).toBeVisible({ timeout: 8000 });
+    // Hand rankings sidebar
+    await expect(page.getByText('HAND RANKINGS')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('can play a full hand vs bot', async ({ page }) => {
+    await page.goto(`${BASE}/play/holdem`);
+    await expect(page.getByRole('button', { name: /deal hand/i })).toBeVisible({ timeout: 10000 });
+
+    // Deal a hand
+    await page.getByRole('button', { name: /deal hand/i }).click();
+    await page.waitForTimeout(400);
+
+    // Phase badge should appear (Pre-Flop)
+    await expect(page.getByText(/pre.?flop/i).first()).toBeVisible({ timeout: 4000 });
+
+    // Player should have hole cards — "YOU" section visible
+    await expect(page.getByText('YOU')).toBeVisible({ timeout: 3000 });
+
+    // "See Flop" button should be present at pre-flop
+    const seeFlop = page.getByRole('button', { name: /see flop/i });
+    await expect(seeFlop).toBeVisible({ timeout: 5000 });
+
+    // Advance to flop
+    await seeFlop.click();
+    await page.waitForTimeout(600);
+
+    // Community section should appear after flop
+    await expect(page.getByText('Community')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/flop/i).first()).toBeVisible({ timeout: 3000 });
+
+    // Check button should now be present
+    const checkBtn = page.getByRole('button', { name: /^check$/i });
+    await expect(checkBtn).toBeVisible({ timeout: 5000 });
+    await checkBtn.click();
+    await page.waitForTimeout(600);
+
+    // Turn — check again
+    const checkBtn2 = page.getByRole('button', { name: /^check$/i });
+    await expect(checkBtn2).toBeVisible({ timeout: 5000 });
+    await checkBtn2.click();
+    await page.waitForTimeout(600);
+
+    // River — check to showdown
+    const checkBtn3 = page.getByRole('button', { name: /^check$/i });
+    await expect(checkBtn3).toBeVisible({ timeout: 5000 });
+    await checkBtn3.click();
+    await page.waitForTimeout(800);
+
+    // Hand should be over — New Hand button
+    await expect(page.getByRole('button', { name: /new hand/i })).toBeVisible({ timeout: 5000 });
+
+    // No error text
+    await expect(page.locator('text=/Error|TypeError|undefined is not/i')).toHaveCount(0);
+  });
+
+  test('game tile on lobby routes to holdem', async ({ page }) => {
+    await page.goto(BASE);
+
+    // Wait for loading screen (2.5s app init) then check for game lobby
+    const gameFloor = page.locator('[class*="gametile"], [class*="game-tile"]').first();
+    const isLobbied = await gameFloor.isVisible({ timeout: 8000 }).catch(() => false);
+
+    if (isLobbied) {
+      // Find Texas Hold'em tile and click it
+      const holdemTile = page.locator('[class*="gametile"]').filter({ hasText: /hold.?em|texas/i }).first();
+      if (await holdemTile.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await holdemTile.click();
+        await expect(page).toHaveURL(/\/play\/holdem/, { timeout: 5000 });
+      } else {
+        await page.goto(`${BASE}/play/holdem`);
+      }
+    } else {
+      // Login wall — navigate directly
+      await page.goto(`${BASE}/play/holdem`);
+    }
+
+    await expect(page.getByText("Texas Hold'em").first()).toBeVisible({ timeout: 8000 });
+    await expect(page.getByRole('button', { name: /deal hand/i })).toBeVisible({ timeout: 8000 });
+  });
+});

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_BACKEND_PROD_URL=https://socialstakes-api.fly.dev

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vercel

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "js-cookie": "^3.0.1",
         "pg": "^8.10.0",
         "poker-evaluator": "^2.0.5",
+        "pokersolver": "^2.1.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-loading": "^2.0.3",
@@ -26,6 +27,7 @@
         "redux-thunk": "^2.4.2",
         "sequelize": "^6.29.0",
         "socket.io": "^4.6.1",
+        "socket.io-client": "^4.6.1",
         "stream": "^0.0.2",
         "validator": "^13.9.0"
       },
@@ -7178,6 +7180,66 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
@@ -13259,6 +13321,15 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/pokersolver": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pokersolver/-/pokersolver-2.1.4.tgz",
+      "integrity": "sha512-vmgZS+K8H8r1RePQykFM5YyvlKo1v3xVec8FMBjg9N6mR2Tj/n/X415w+lG67FWbrk71D/CADmKFinDgaQlAsw==",
+      "engines": [
+        "node >= 4.0.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -15969,24 +16040,28 @@
         }
       }
     },
-    "node_modules/socket.io-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
-      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
-    "node_modules/socket.io-parser/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -15997,10 +16072,35 @@
         }
       }
     },
-    "node_modules/socket.io-parser/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/socket.io/node_modules/debug": {
       "version": "4.3.4",
@@ -18133,6 +18233,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -23380,6 +23488,39 @@
         }
       }
     },
+    "engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "engine.io-parser": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+          "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="
+        },
+        "ws": {
+          "version": "8.18.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+          "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+          "requires": {}
+        }
+      }
+    },
     "engine.io-parser": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.6.tgz",
@@ -27896,6 +28037,11 @@
         }
       }
     },
+    "pokersolver": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/pokersolver/-/pokersolver-2.1.4.tgz",
+      "integrity": "sha512-vmgZS+K8H8r1RePQykFM5YyvlKo1v3xVec8FMBjg9N6mR2Tj/n/X415w+lG67FWbrk71D/CADmKFinDgaQlAsw=="
+    },
     "postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -29677,27 +29823,43 @@
         }
       }
     },
-    "socket.io-parser": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.2.tgz",
-      "integrity": "sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==",
+    "socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "requires": {
         "@socket.io/component-emitter": "~3.1.0",
-        "debug": "~4.3.1"
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
         }
       }
     },
@@ -31307,6 +31469,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,12 +21,13 @@
     "redux-thunk": "^2.4.2",
     "sequelize": "^6.29.0",
     "socket.io": "^4.6.1",
+    "socket.io-client": "^4.6.1",
     "stream": "^0.0.2",
     "validator": "^13.9.0"
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "js-cookie": "^3.0.1",
     "pg": "^8.10.0",
     "poker-evaluator": "^2.0.5",
+    "pokersolver": "^2.1.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-loading": "^2.0.3",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,6 +31,7 @@ import VerifyHandPage from './components/VerifyHandPage';
 import CoinFlip from './components/games/CoinFlip';
 import HiLo from './components/games/HiLo';
 import AceyDuecey from './components/games/AceyDuecey';
+import HoldEm from './components/games/HoldEm';
 import RemoveFriendModal from './components/RemoveFriendModal';
 import ProfileButtonModal from './components/ProfileButtonModal';
 import StartConversationModal from './components/StartConversationModal';
@@ -245,6 +246,9 @@ function App() {
             {isLoaded && <AceyDuecey />}
           </Route>
 
+          <Route path="/play/holdem" exact>
+            {isLoaded && <HoldEm />}
+          </Route>
 
           <Route>
             <h1>404:Unknown Route</h1>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import Navigation from './components/Navigation';
+import LandingPage from './components/LandingPage';
 import LoginModal from './components/LoginModal';
 import SignupModal from './components/SignupModal';
 import GameFloor from './components/GameFloor';
@@ -207,7 +208,8 @@ function App() {
         <Switch>
 
           <Route path="/" exact>
-            {isLoaded && <GameFloor/>}
+            {isLoaded && !user && <LandingPage />}
+            {isLoaded && user && <GameFloor/>}
           </Route>
 
           <Route path="/friends" exact>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -32,6 +32,7 @@ import CoinFlip from './components/games/CoinFlip';
 import HiLo from './components/games/HiLo';
 import AceyDuecey from './components/games/AceyDuecey';
 import HoldEm from './components/games/HoldEm';
+import Blackjack from './components/games/Blackjack';
 import RemoveFriendModal from './components/RemoveFriendModal';
 import ProfileButtonModal from './components/ProfileButtonModal';
 import StartConversationModal from './components/StartConversationModal';
@@ -248,6 +249,10 @@ function App() {
 
           <Route path="/play/holdem" exact>
             {isLoaded && <HoldEm />}
+          </Route>
+
+          <Route path="/play/blackjack" exact>
+            {isLoaded && <Blackjack />}
           </Route>
 
           <Route>

--- a/frontend/src/components/AboutMeModal/index.js
+++ b/frontend/src/components/AboutMeModal/index.js
@@ -30,10 +30,7 @@ const AboutMeModal = () => {
       case 'linkedin':
         window.open('https://www.linkedin.com/in/donovan-crader-898413242/', '_blank');
         break;
-      case 'github':
-        window.open('https://github.com/dcraderdev/SocialStakes/wiki', '_blank');
-        break;
-      case 'portfolio':
+case 'portfolio':
         window.open('https://donovancrader.dev/', '_blank');
         break;
       default:
@@ -69,22 +66,7 @@ const AboutMeModal = () => {
       </div>
 
       <div className="aboutmemodal-content flex center">
-        <div className="content-container flex  center">
-          <div className="content-icon" >
-            <div className="aboutmemodal-icon flex" onClick={() => navTo('github')}>
-              <i className="fa-brands fa-github"></i>
-            </div>
-          </div>
-
-
-
-
-          <div className="content-message flex center">
-            <div className="content-link" onClick={() => navTo('github')}>Interested in the code magic behind this site?</div>
-          </div>
-        </div>
-
-        <div className="content-container flex center">
+<div className="content-container flex center">
           <div className="content-icon">
             <div className="aboutmemodal-icon flex center"  onClick={() => navTo('portfolio')}>
               <img

--- a/frontend/src/components/CreatingGameView/index.js
+++ b/frontend/src/components/CreatingGameView/index.js
@@ -15,7 +15,6 @@ import { ModalContext } from '../../context/ModalContext';
 
 import './CreatingGameView.css';
 import FriendTile from '../FriendTile';
-import { Pricing } from 'aws-sdk';
 
 const CreatingGameView = () => {
   const dispatch = useDispatch();

--- a/frontend/src/components/GameTile/index.js
+++ b/frontend/src/components/GameTile/index.js
@@ -18,6 +18,7 @@ const GameTile = ({game, cbFunc, delay, animateTiles}) => {
     hi_lo: '/play/hilo',
     acey_duecey: '/play/acey',
     poker: '/play/holdem',
+    single_blackjack: '/play/blackjack',
   };
 
   const handleClick = () => {

--- a/frontend/src/components/GameTile/index.js
+++ b/frontend/src/components/GameTile/index.js
@@ -17,6 +17,7 @@ const GameTile = ({game, cbFunc, delay, animateTiles}) => {
     coin_flip: '/play/coinflip',
     hi_lo: '/play/hilo',
     acey_duecey: '/play/acey',
+    poker: '/play/holdem',
   };
 
   const handleClick = () => {

--- a/frontend/src/components/HistoryPage/index.js
+++ b/frontend/src/components/HistoryPage/index.js
@@ -23,36 +23,6 @@ function HistoryPage() {
         <h1 className="ss-h1">Your last 30 days</h1>
         <p className="ss-sub">All hands cryptographically logged. Click any row to replay or verify.</p>
 
-        <div className="ss-grid-stats">
-          <div className="ss-card ss-stat-card">
-            <div className="ss-stat-label">Hands played</div>
-            <div className="ss-stat-value">{stats.handsPlayed.toLocaleString()}</div>
-            <div className="ss-stat-sub">+{stats.handsDelta} from prior month</div>
-          </div>
-          <div className="ss-card ss-stat-card">
-            <div className="ss-stat-label">Net P&amp;L</div>
-            <div className="ss-stat-value" style={{ color: stats.netPL >= 0 ? 'var(--ss-green)' : 'var(--ss-red)' }}>
-              {stats.netPL >= 0 ? '+ ' : '- '}$ {Math.abs(stats.netPL).toLocaleString()}
-            </div>
-            <div className="ss-stat-sub">All-time + $4,820</div>
-          </div>
-          <div className="ss-card ss-stat-card">
-            <div className="ss-stat-label">Win rate</div>
-            <div className="ss-stat-value">{stats.winRate.toFixed(1)}%</div>
-            <div className="ss-stat-sub">House edge 0.5%</div>
-          </div>
-          <div className="ss-card ss-stat-card">
-            <div className="ss-stat-label">Best session</div>
-            <div className="ss-stat-value" style={{ color: 'var(--ss-green)' }}>+ $ {stats.bestSession.amount}</div>
-            <div className="ss-stat-sub">{stats.bestSession.table}</div>
-          </div>
-          <div className="ss-card ss-stat-card">
-            <div className="ss-stat-label">Worst session</div>
-            <div className="ss-stat-value" style={{ color: 'var(--ss-red)' }}>− $ {stats.worstSession.amount}</div>
-            <div className="ss-stat-sub">{stats.worstSession.table}</div>
-          </div>
-        </div>
-
         <div className="ss-side-grid">
           <div className="ss-card" style={{ padding: 20 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>

--- a/frontend/src/components/LandingPage/LandingPage.css
+++ b/frontend/src/components/LandingPage/LandingPage.css
@@ -1,0 +1,1214 @@
+/* ============================================================
+   LandingPage.css — Social Stakes marketing page
+   Dark casino aesthetic, gold/amber accents, mobile-first
+   ============================================================ */
+
+/* ── Base ── */
+.lp-root {
+  min-height: 100vh;
+  background: #0a0b0e;
+  color: #f6f3ec;
+  font-family: var(--ss-font, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Inter", Helvetica, Arial, sans-serif);
+  overflow-x: hidden;
+  position: relative;
+  top: 0;
+}
+
+.lp-gold { color: #e5b34c; }
+.lp-red-card { color: #ef5d5d; }
+.lp-suit-gold { color: #e5b34c; }
+.lp-suit-small { font-size: 0.65em; opacity: 0.8; margin-left: 1px; }
+
+/* ── Nav ── */
+.lp-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  background: rgba(10, 11, 14, 0.92);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(229, 179, 76, 0.15);
+}
+
+.lp-nav-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.lp-nav-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.lp-nav-logo {
+  width: 36px;
+  height: 36px;
+  filter: drop-shadow(0 0 6px rgba(229, 179, 76, 0.4));
+}
+
+.lp-nav-name {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #f6f3ec;
+}
+
+.lp-nav-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+/* ── Buttons ── */
+.lp-btn-ghost {
+  background: transparent;
+  border: 1px solid rgba(229, 179, 76, 0.35);
+  color: #e5b34c;
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+  font-family: inherit;
+  letter-spacing: 0.03em;
+}
+.lp-btn-ghost:hover {
+  background: rgba(229, 179, 76, 0.08);
+  border-color: rgba(229, 179, 76, 0.6);
+}
+
+.lp-btn-gold {
+  background: #e5b34c;
+  color: #0a0b0e;
+  border: none;
+  padding: 8px 20px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s, box-shadow 0.2s;
+  font-family: inherit;
+  letter-spacing: 0.04em;
+}
+.lp-btn-gold:hover {
+  background: #f5c96e;
+  box-shadow: 0 0 20px rgba(229, 179, 76, 0.4);
+}
+
+.lp-btn-hero-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: #e5b34c;
+  color: #0a0b0e;
+  border: none;
+  padding: 16px 36px;
+  border-radius: 999px;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+  letter-spacing: 0.04em;
+  transition: background 0.2s, box-shadow 0.2s, transform 0.15s;
+  box-shadow: 0 0 30px rgba(229, 179, 76, 0.3);
+}
+.lp-btn-hero-primary:hover {
+  background: #f5c96e;
+  box-shadow: 0 0 40px rgba(229, 179, 76, 0.55);
+  transform: translateY(-1px);
+}
+
+.lp-btn-hero-ghost {
+  background: transparent;
+  border: 1px solid rgba(246, 243, 236, 0.25);
+  color: #b6bac3;
+  padding: 15px 32px;
+  border-radius: 999px;
+  font-size: 15px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  letter-spacing: 0.03em;
+  transition: border-color 0.2s, color 0.2s;
+}
+.lp-btn-hero-ghost:hover {
+  border-color: rgba(229, 179, 76, 0.45);
+  color: #e5b34c;
+}
+
+.lp-btn-arrow { font-size: 18px; }
+
+/* ── Sections ── */
+.lp-section-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.lp-section-header {
+  text-align: center;
+  margin-bottom: 56px;
+}
+
+.lp-section-title {
+  font-size: clamp(24px, 4vw, 40px);
+  font-weight: 700;
+  margin: 0 0 12px;
+  letter-spacing: -0.02em;
+  color: #f6f3ec;
+}
+
+.lp-section-sub {
+  font-size: 16px;
+  color: #7c8290;
+  margin: 0;
+}
+
+/* ── Hero ── */
+.lp-hero {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  padding: 100px 24px 80px;
+}
+
+.lp-hero-bg-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(229, 179, 76, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(229, 179, 76, 0.04) 1px, transparent 1px);
+  background-size: 60px 60px;
+  pointer-events: none;
+}
+
+.lp-hero-glow {
+  position: absolute;
+  top: 30%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 700px;
+  height: 700px;
+  background: radial-gradient(ellipse, rgba(229, 179, 76, 0.08) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.lp-hero-inner {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  max-width: 760px;
+}
+
+.lp-hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(229, 179, 76, 0.1);
+  border: 1px solid rgba(229, 179, 76, 0.25);
+  color: #e5b34c;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 16px;
+  border-radius: 999px;
+  margin-bottom: 28px;
+  letter-spacing: 0.04em;
+}
+
+.lp-eyebrow-dot {
+  width: 6px;
+  height: 6px;
+  background: #4ade80;
+  border-radius: 50%;
+  box-shadow: 0 0 6px #4ade80;
+  animation: lp-pulse-dot 2s infinite;
+}
+
+@keyframes lp-pulse-dot {
+  0%, 100% { opacity: 1; box-shadow: 0 0 6px #4ade80; }
+  50% { opacity: 0.6; box-shadow: 0 0 2px #4ade80; }
+}
+
+.lp-hero-headline {
+  font-size: clamp(42px, 7vw, 80px);
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  margin: 0 0 24px;
+  color: #f6f3ec;
+}
+
+.lp-hero-sub {
+  font-size: clamp(16px, 2vw, 20px);
+  color: #b6bac3;
+  line-height: 1.6;
+  margin: 0 0 40px;
+}
+
+.lp-br-desk { display: none; }
+@media (min-width: 640px) { .lp-br-desk { display: inline; } }
+
+.lp-hero-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: center;
+  margin-bottom: 48px;
+}
+
+.lp-hero-stats {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 32px;
+  flex-wrap: wrap;
+}
+
+.lp-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.lp-stat-n {
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.lp-stat-l {
+  font-size: 12px;
+  color: #7c8290;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.lp-stat-divider {
+  width: 1px;
+  height: 36px;
+  background: rgba(229, 179, 76, 0.2);
+}
+
+/* Floating chips deco */
+.lp-hero-chips {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.lp-chip-float {
+  position: absolute;
+  opacity: 0.12;
+  animation: lp-float linear infinite;
+  filter: sepia(1) saturate(2) hue-rotate(15deg) brightness(1.2);
+}
+
+.lp-cf-1 { width: 80px; top: 20%; left: 8%; animation-duration: 18s; animation-delay: 0s; }
+.lp-cf-2 { width: 55px; top: 60%; left: 85%; animation-duration: 22s; animation-delay: -7s; }
+.lp-cf-3 { width: 100px; top: 75%; left: 12%; animation-duration: 26s; animation-delay: -14s; }
+
+@keyframes lp-float {
+  0% { transform: translateY(0) rotate(0deg); }
+  50% { transform: translateY(-30px) rotate(180deg); }
+  100% { transform: translateY(0) rotate(360deg); }
+}
+
+/* Decorative hero cards */
+.lp-hero-cards-deco {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.lp-deco-card {
+  position: absolute;
+  width: 72px;
+  height: 100px;
+  background: #12141a;
+  border: 1px solid rgba(229, 179, 76, 0.2);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 8px;
+  font-size: 18px;
+  font-weight: 800;
+  color: #f6f3ec;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  animation: lp-card-drift linear infinite;
+}
+
+.lp-deco-suit {
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.lp-deco-c1 { top: 15%; left: 5%; animation-duration: 20s; animation-delay: 0s; opacity: 0.35; transform: rotate(-12deg); }
+.lp-deco-c2 { top: 55%; left: 3%; animation-duration: 25s; animation-delay: -8s; opacity: 0.25; transform: rotate(8deg); }
+.lp-deco-c3 { top: 10%; right: 5%; animation-duration: 22s; animation-delay: -4s; opacity: 0.3; transform: rotate(15deg); }
+.lp-deco-c4 { top: 65%; right: 4%; animation-duration: 18s; animation-delay: -12s; opacity: 0.2; transform: rotate(-6deg); }
+
+@media (max-width: 640px) {
+  .lp-deco-c1, .lp-deco-c2, .lp-deco-c3, .lp-deco-c4 { display: none; }
+}
+
+@keyframes lp-card-drift {
+  0%, 100% { transform: translateY(0) rotate(var(--r, -12deg)); }
+  50% { transform: translateY(-20px) rotate(calc(var(--r, -12deg) + 5deg)); }
+}
+
+/* ── Games grid ── */
+.lp-games {
+  padding: 100px 0;
+  background: #0a0b0e;
+  border-top: 1px solid rgba(229, 179, 76, 0.08);
+}
+
+.lp-games-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 200px), 1fr));
+  gap: 18px;
+}
+
+@media (min-width: 768px) {
+  .lp-games-grid { grid-template-columns: repeat(4, 1fr); }
+}
+@media (min-width: 1100px) {
+  .lp-games-grid { grid-template-columns: repeat(7, 1fr); }
+}
+
+.lp-game-card {
+  background: #12141a;
+  border: 1px solid #262a33;
+  border-radius: 14px;
+  padding: 18px 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
+  position: relative;
+  overflow: hidden;
+}
+
+.lp-game-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at top, rgba(229, 179, 76, 0.06), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.lp-game-card:hover {
+  border-color: rgba(229, 179, 76, 0.35);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  transform: translateY(-3px);
+}
+.lp-game-card:hover::before { opacity: 1; }
+
+.lp-game-card-badge {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.lp-game-card-preview {
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.lp-game-card-body { flex: 1; }
+
+.lp-game-card-name {
+  font-size: 13px;
+  font-weight: 700;
+  color: #f6f3ec;
+  margin-bottom: 4px;
+  line-height: 1.2;
+}
+
+.lp-game-card-desc {
+  font-size: 11px;
+  color: #7c8290;
+  line-height: 1.4;
+}
+
+.lp-game-card-cta {
+  font-size: 11px;
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+/* ── Game card animations ── */
+
+/* Blackjack cards */
+.lp-anim-cards {
+  position: relative;
+  width: 80px;
+  height: 72px;
+}
+
+.lp-card {
+  position: absolute;
+  width: 40px;
+  height: 58px;
+  perspective: 200px;
+}
+.lp-card-1 { left: 0; top: 4px; transform: rotate(-10deg); z-index: 1; animation: lp-flip-card 4s ease-in-out infinite; animation-delay: 0s; }
+.lp-card-2 { left: 18px; top: 0; z-index: 2; animation: lp-flip-card 4s ease-in-out infinite; animation-delay: 0.8s; }
+.lp-card-3 { left: 36px; top: 6px; transform: rotate(10deg); z-index: 1; animation: lp-flip-card 4s ease-in-out infinite; animation-delay: 1.6s; }
+
+.lp-card-inner {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  animation: lp-card-3d 4s ease-in-out infinite;
+}
+.lp-card-1 .lp-card-inner { animation-delay: 0s; }
+.lp-card-2 .lp-card-inner { animation-delay: 0.8s; }
+.lp-card-3 .lp-card-inner { animation-delay: 1.6s; }
+
+@keyframes lp-card-3d {
+  0%, 35%, 100% { transform: rotateY(0deg); }
+  45%, 90% { transform: rotateY(180deg); }
+}
+
+.lp-card-front,
+.lp-card-back-face {
+  position: absolute;
+  inset: 0;
+  border-radius: 5px;
+  backface-visibility: hidden;
+  display: flex;
+  flex-direction: column;
+  padding: 3px 4px;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.lp-card-front {
+  background: #f6f3ec;
+  color: #12141a;
+  border: 1px solid rgba(255,255,255,0.1);
+}
+
+.lp-card-back-face {
+  background: linear-gradient(135deg, #1a3a5c, #0e2840);
+  transform: rotateY(180deg);
+  border: 1px solid rgba(229, 179, 76, 0.3);
+}
+.lp-card-back-face::after {
+  content: '♠';
+  font-size: 18px;
+  color: rgba(229, 179, 76, 0.5);
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* Chip stack */
+.lp-anim-chips {
+  position: relative;
+  width: 44px;
+  height: 70px;
+}
+
+.lp-chip {
+  position: absolute;
+  width: 38px;
+  height: 10px;
+  border-radius: 50%;
+  left: 3px;
+}
+.lp-chip-0 { bottom: 50px; background: #c084fc; box-shadow: 0 2px 8px rgba(192,132,252,0.4); animation: lp-chip-bob 2.5s ease-in-out infinite 0.0s; }
+.lp-chip-1 { bottom: 38px; background: #ef5d5d; box-shadow: 0 2px 8px rgba(239,93,93,0.4); animation: lp-chip-bob 2.5s ease-in-out infinite 0.2s; }
+.lp-chip-2 { bottom: 26px; background: #6aa9ff; box-shadow: 0 2px 8px rgba(106,169,255,0.4); animation: lp-chip-bob 2.5s ease-in-out infinite 0.4s; }
+.lp-chip-3 { bottom: 14px; background: #e5b34c; box-shadow: 0 2px 8px rgba(229,179,76,0.4); animation: lp-chip-bob 2.5s ease-in-out infinite 0.6s; }
+.lp-chip-4 { bottom: 2px; background: #4ade80; box-shadow: 0 2px 8px rgba(74,222,128,0.4); animation: lp-chip-bob 2.5s ease-in-out infinite 0.8s; }
+
+@keyframes lp-chip-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+
+/* Coin spin */
+.lp-anim-coin {
+  width: 56px;
+  height: 56px;
+  perspective: 200px;
+}
+
+.lp-coin {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  transform-style: preserve-3d;
+  animation: lp-coin-flip 2.4s ease-in-out infinite;
+}
+
+.lp-coin-face {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 900;
+  backface-visibility: hidden;
+}
+
+.lp-coin-h {
+  background: linear-gradient(135deg, #e5b34c, #f5c96e);
+  color: #3d2800;
+  box-shadow: 0 0 20px rgba(229, 179, 76, 0.5);
+}
+
+.lp-coin-t {
+  background: linear-gradient(135deg, #cf9e3a, #e5b34c);
+  color: #3d2800;
+  transform: rotateY(180deg);
+}
+
+@keyframes lp-coin-flip {
+  0% { transform: rotateY(0deg); }
+  50% { transform: rotateY(900deg); }
+  70%, 100% { transform: rotateY(1080deg); }
+}
+
+/* Hi/Lo */
+.lp-anim-hilo {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.lp-hilo-card {
+  width: 34px;
+  height: 48px;
+  background: #f6f3ec;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  padding: 3px 4px;
+  font-size: 12px;
+  font-weight: 800;
+  color: #12141a;
+}
+
+.lp-hilo-arrows {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 10px;
+}
+
+.lp-arrow-up { color: #4ade80; animation: lp-arrow-pulse 1.5s ease-in-out infinite; }
+.lp-arrow-down { color: #ef5d5d; animation: lp-arrow-pulse 1.5s ease-in-out infinite 0.75s; }
+
+@keyframes lp-arrow-pulse {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
+.lp-hilo-reveal {
+  animation: lp-reveal 3s ease-in-out infinite;
+}
+
+@keyframes lp-reveal {
+  0%, 30% { opacity: 0; transform: translateY(-8px); }
+  50%, 80% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(8px); }
+}
+
+/* Acey-Duecey */
+.lp-anim-acey {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.lp-acey-card {
+  width: 30px;
+  height: 44px;
+  background: #f6f3ec;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  padding: 3px;
+  font-size: 11px;
+  font-weight: 800;
+  color: #12141a;
+}
+
+.lp-acey-mid {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.lp-acey-mid-label {
+  font-size: 8px;
+  color: #7c8290;
+  white-space: nowrap;
+}
+
+.lp-acey-mid-card {
+  width: 30px;
+  height: 44px;
+  background: #f6f3ec;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  padding: 3px;
+  font-size: 11px;
+  font-weight: 800;
+  color: #12141a;
+  animation: lp-acey-flip 3.5s ease-in-out infinite;
+}
+
+@keyframes lp-acey-flip {
+  0%, 20% { opacity: 0; transform: scaleX(0); }
+  40%, 85% { opacity: 1; transform: scaleX(1); }
+  100% { opacity: 0; transform: scaleX(0); }
+}
+
+/* Slots */
+.lp-anim-slots {
+  display: flex;
+  gap: 4px;
+  height: 60px;
+  overflow: hidden;
+}
+
+.lp-slot-reel {
+  width: 22px;
+  height: 60px;
+  background: #1d2029;
+  border: 1px solid #262a33;
+  border-radius: 4px;
+  overflow: hidden;
+  position: relative;
+}
+
+.lp-slot-strip {
+  display: flex;
+  flex-direction: column;
+  animation: lp-reel-spin 1.8s cubic-bezier(0.25,0.1,0.25,1) infinite;
+}
+
+.lp-strip-0 { animation-delay: 0s; }
+.lp-strip-1 { animation-delay: 0.2s; }
+.lp-strip-2 { animation-delay: 0.4s; }
+
+@keyframes lp-reel-spin {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(-80px); }
+}
+
+.lp-slot-sym {
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: #e5b34c;
+}
+
+/* Roulette */
+.lp-anim-roulette {
+  position: relative;
+  width: 68px;
+  height: 68px;
+}
+
+.lp-wheel {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  position: relative;
+  overflow: hidden;
+  border: 3px solid #e5b34c;
+  animation: lp-wheel-turn 4s linear infinite;
+  box-shadow: 0 0 12px rgba(229, 179, 76, 0.3);
+}
+
+@keyframes lp-wheel-turn {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.lp-wheel-seg {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 2px;
+  height: 50%;
+  transform-origin: bottom center;
+}
+
+.lp-seg-red { background: #ef5d5d22; }
+.lp-seg-dark { background: #f6f3ec08; }
+
+.lp-wheel-center {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: 16px;
+  height: 16px;
+  background: #e5b34c;
+  border-radius: 50%;
+  z-index: 2;
+  box-shadow: 0 0 8px rgba(229, 179, 76, 0.6);
+}
+
+.lp-roulette-ball {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  background: #f6f3ec;
+  border-radius: 50%;
+  top: 4px;
+  left: 28px;
+  box-shadow: 0 0 4px rgba(255,255,255,0.5);
+  animation: lp-ball-orbit 4s linear infinite;
+  transform-origin: 0px 28px;
+}
+
+@keyframes lp-ball-orbit {
+  from { transform: rotate(0deg) translateY(0); }
+  to { transform: rotate(-360deg) translateY(0); }
+}
+
+/* ── Why section ── */
+.lp-why {
+  padding: 100px 0;
+  background: #0d0f14;
+  border-top: 1px solid rgba(229, 179, 76, 0.08);
+}
+
+.lp-why-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .lp-why-grid { grid-template-columns: repeat(3, 1fr); }
+}
+
+.lp-why-card {
+  background: #12141a;
+  border: 1px solid #262a33;
+  border-radius: 16px;
+  padding: 32px 28px;
+  transition: border-color 0.2s, transform 0.15s;
+}
+
+.lp-why-card:hover {
+  border-color: rgba(229, 179, 76, 0.3);
+  transform: translateY(-4px);
+}
+
+.lp-why-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+  font-size: 22px;
+}
+
+.lp-why-icon-gold { background: rgba(229, 179, 76, 0.15); color: #e5b34c; }
+.lp-why-icon-blue { background: rgba(106, 169, 255, 0.15); color: #6aa9ff; }
+.lp-why-icon-green { background: rgba(74, 222, 128, 0.15); color: #4ade80; }
+
+.lp-icon-glyph { font-size: 20px; }
+
+.lp-why-title {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0 0 12px;
+  color: #f6f3ec;
+}
+
+.lp-why-desc {
+  font-size: 14px;
+  color: #7c8290;
+  line-height: 1.7;
+  margin: 0 0 16px;
+}
+
+.lp-why-link {
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+}
+.lp-why-link:hover { text-decoration: underline; }
+
+/* ── How it works ── */
+.lp-how {
+  padding: 100px 0;
+  background: #0a0b0e;
+  border-top: 1px solid rgba(229, 179, 76, 0.08);
+  scroll-margin-top: 60px;
+}
+
+.lp-steps {
+  display: grid;
+  gap: 0;
+  grid-template-columns: 1fr;
+  margin-bottom: 64px;
+}
+
+@media (min-width: 768px) {
+  .lp-steps { grid-template-columns: repeat(4, 1fr); }
+}
+
+.lp-step {
+  padding: 28px 24px;
+  position: relative;
+  border-left: 2px solid rgba(229, 179, 76, 0.2);
+}
+
+@media (min-width: 768px) {
+  .lp-step {
+    border-left: none;
+    border-top: 2px solid rgba(229, 179, 76, 0.2);
+  }
+}
+
+.lp-step-num {
+  font-size: 36px;
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  margin-bottom: 10px;
+  line-height: 1;
+}
+
+.lp-step-label {
+  font-size: 16px;
+  font-weight: 700;
+  color: #f6f3ec;
+  margin-bottom: 8px;
+}
+
+.lp-step-desc {
+  font-size: 13px;
+  color: #7c8290;
+  line-height: 1.6;
+}
+
+.lp-step-connector { display: none; }
+
+/* Provably fair explainer */
+.lp-pf-box {
+  background: #12141a;
+  border: 1px solid rgba(229, 179, 76, 0.2);
+  border-radius: 16px;
+  padding: 36px 32px;
+}
+
+.lp-pf-header {
+  margin-bottom: 28px;
+}
+
+.lp-pf-badge {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(229, 179, 76, 0.35);
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(229, 179, 76, 0.08);
+}
+
+.lp-pf-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 28px;
+}
+
+@media (min-width: 768px) {
+  .lp-pf-steps {
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+  }
+}
+
+.lp-pf-step {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  flex: 1;
+}
+
+.lp-pf-icon {
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  background: rgba(229, 179, 76, 0.12);
+  border: 1px solid rgba(229, 179, 76, 0.3);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  color: #e5b34c;
+}
+
+.lp-pf-text {
+  font-size: 14px;
+  color: #b6bac3;
+  line-height: 1.6;
+}
+
+.lp-pf-arrow {
+  font-size: 22px;
+  color: rgba(229, 179, 76, 0.4);
+  font-weight: 700;
+  min-width: 24px;
+  text-align: center;
+  display: none;
+}
+
+@media (min-width: 768px) { .lp-pf-arrow { display: block; } }
+
+.lp-pf-cta {
+  font-size: 14px;
+}
+
+/* ── Quotes ── */
+.lp-quotes {
+  padding: 100px 0;
+  background: #0d0f14;
+  border-top: 1px solid rgba(229, 179, 76, 0.08);
+}
+
+.lp-quotes-note {
+  font-size: 13px;
+  color: rgba(124, 130, 144, 0.7);
+  font-style: italic;
+}
+
+.lp-quotes-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) { .lp-quotes-grid { grid-template-columns: repeat(3, 1fr); } }
+
+.lp-quote-card {
+  background: #12141a;
+  border: 1px solid #262a33;
+  border-radius: 16px;
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: border-color 0.2s;
+}
+
+.lp-quote-card:hover {
+  border-color: rgba(229, 179, 76, 0.2);
+}
+
+.lp-quote-mark {
+  font-size: 48px;
+  font-weight: 900;
+  line-height: 0.8;
+  height: 24px;
+  display: block;
+}
+
+.lp-quote-text {
+  font-size: 15px;
+  color: #b6bac3;
+  line-height: 1.65;
+  margin: 0;
+  flex: 1;
+}
+
+.lp-quote-attr {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 4px;
+  border-top: 1px solid #262a33;
+}
+
+.lp-quote-avatar {
+  width: 36px;
+  height: 36px;
+  min-width: 36px;
+  background: linear-gradient(135deg, #e5b34c, #cf9e3a);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 800;
+  color: #0a0b0e;
+}
+
+.lp-quote-name {
+  font-size: 13px;
+  font-weight: 700;
+  color: #f6f3ec;
+}
+
+.lp-quote-sub {
+  font-size: 12px;
+  color: #7c8290;
+}
+
+/* ── Final CTA ── */
+.lp-final-cta {
+  padding: 120px 0;
+  background: #0a0b0e;
+  border-top: 1px solid rgba(229, 179, 76, 0.08);
+  position: relative;
+  overflow: hidden;
+  text-align: center;
+}
+
+.lp-final-glow {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 600px;
+  height: 600px;
+  background: radial-gradient(ellipse, rgba(229, 179, 76, 0.1) 0%, transparent 65%);
+  pointer-events: none;
+}
+
+.lp-final-inner {
+  position: relative;
+  z-index: 2;
+}
+
+.lp-final-title {
+  font-size: clamp(32px, 5vw, 60px);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin: 0 0 16px;
+}
+
+.lp-final-sub {
+  font-size: 18px;
+  color: #7c8290;
+  margin: 0 0 40px;
+}
+
+.lp-final-btn {
+  font-size: 18px;
+  padding: 18px 48px;
+}
+
+.lp-final-footnote {
+  margin-top: 20px;
+  font-size: 13px;
+  color: #7c8290;
+}
+
+/* ── Footer ── */
+.lp-footer {
+  background: #070809;
+  border-top: 1px solid rgba(229, 179, 76, 0.1);
+  padding: 32px 0;
+}
+
+.lp-footer-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.lp-footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.lp-footer-logo {
+  width: 24px;
+  height: 24px;
+  opacity: 0.7;
+}
+
+.lp-footer-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: #7c8290;
+}
+
+.lp-footer-links {
+  display: flex;
+  gap: 8px;
+}
+
+.lp-footer-link {
+  background: none;
+  border: none;
+  color: #7c8290;
+  font-size: 13px;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: color 0.2s;
+}
+.lp-footer-link:hover { color: #e5b34c; }
+
+.lp-footer-note {
+  font-size: 12px;
+  color: #3d414a;
+  width: 100%;
+  text-align: center;
+}
+
+@media (min-width: 640px) {
+  .lp-footer-note { width: auto; text-align: left; }
+}

--- a/frontend/src/components/LandingPage/LandingPage.css
+++ b/frontend/src/components/LandingPage/LandingPage.css
@@ -267,39 +267,6 @@
   margin-bottom: 48px;
 }
 
-.lp-hero-stats {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 32px;
-  flex-wrap: wrap;
-}
-
-.lp-stat {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-}
-
-.lp-stat-n {
-  font-size: 28px;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-}
-
-.lp-stat-l {
-  font-size: 12px;
-  color: #7c8290;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.lp-stat-divider {
-  width: 1px;
-  height: 36px;
-  background: rgba(229, 179, 76, 0.2);
-}
 
 /* Floating chips deco */
 .lp-hero-chips {

--- a/frontend/src/components/LandingPage/index.js
+++ b/frontend/src/components/LandingPage/index.js
@@ -1,0 +1,462 @@
+import React, { useContext, useEffect, useRef } from 'react';
+import { ModalContext } from '../../context/ModalContext';
+import socialstakesCards from '../../images/socialstakes-logo-cards2.svg';
+import goldChip from '../../images/gold-poker-chip.svg';
+import './LandingPage.css';
+
+const GAMES = [
+  {
+    id: 'multi_blackjack',
+    name: 'Multiplayer Blackjack',
+    tag: 'LIVE',
+    desc: 'Real tables, real players. Beat the dealer together.',
+    icon: 'BJ',
+    suit: '♠',
+    color: 'var(--ss-gold)',
+    anim: 'card-flip',
+  },
+  {
+    id: 'poker',
+    name: "Texas Hold'em",
+    tag: 'SOON',
+    desc: 'Six players, one pot. May the best hand win.',
+    icon: '♦',
+    suit: '♣',
+    color: '#c084fc',
+    anim: 'chip-stack',
+  },
+  {
+    id: 'coin_flip',
+    name: 'Coin Flip',
+    tag: 'SOLO',
+    desc: 'Heads or tails. 50/50. Instant result.',
+    icon: 'C',
+    suit: null,
+    color: '#fbbf24',
+    anim: 'coin-spin',
+  },
+  {
+    id: 'hi_lo',
+    name: 'Hi / Lo',
+    tag: 'SOLO',
+    desc: 'Will the next card be higher or lower?',
+    icon: '↕',
+    suit: '♥',
+    color: '#ef5d5d',
+    anim: 'card-slide',
+  },
+  {
+    id: 'acey_duecey',
+    name: 'Acey-Duecey',
+    tag: 'SOLO',
+    desc: 'Will the third card fall between the first two?',
+    icon: 'A',
+    suit: '2',
+    color: '#6aa9ff',
+    anim: 'two-cards',
+  },
+  {
+    id: 'slots',
+    name: 'Slots',
+    tag: 'SOON',
+    desc: 'Pull the lever. Three in a row takes the pot.',
+    icon: '7',
+    suit: null,
+    color: '#4ade80',
+    anim: 'reel-spin',
+  },
+  {
+    id: 'roulette',
+    name: 'Roulette',
+    tag: 'SOON',
+    desc: 'Red or black. Zero to thirty-six. Place your bets.',
+    icon: '○',
+    suit: null,
+    color: '#ef5d5d',
+    anim: 'wheel-spin',
+  },
+];
+
+const STEPS = [
+  { num: '01', label: 'Sign Up Free', desc: 'No credit card. No real money. Just a username and password.' },
+  { num: '02', label: 'Get Free Chips', desc: 'Start with $10,000 in demo chips. Lose it all? We reset you.' },
+  { num: '03', label: 'Invite Friends', desc: 'Share a private table link. They join from anywhere.' },
+  { num: '04', label: 'Play & Verify', desc: 'Every hand is provably fair — check the math yourself.' },
+];
+
+const QUOTES = [
+  {
+    text: "Finally a way to verify the dealer isn't cheating. I audited three hands and the math checked out every time.",
+    name: 'Alex R.',
+    sub: 'Software engineer, plays Friday nights',
+  },
+  {
+    text: "Brought back our Saturday poker night across three time zones. Social Stakes is the only app that didn't feel like a grind.",
+    name: 'Maya T.',
+    sub: 'Plays Texas Hold\'em with college friends',
+  },
+  {
+    text: "The provably fair thing sold me instantly. Every other site just says 'trust us'. These guys show their work.",
+    name: 'Jordan K.',
+    sub: 'Skeptic turned regular',
+  },
+];
+
+function GameCard({ game, onCTA }) {
+  return (
+    <div className={`lp-game-card lp-anim-${game.anim}`} onClick={onCTA}>
+      <div className="lp-game-card-badge" style={{ color: game.color }}>
+        {game.tag}
+      </div>
+      <div className="lp-game-card-preview">
+        <GameCardAnim game={game} />
+      </div>
+      <div className="lp-game-card-body">
+        <div className="lp-game-card-name">{game.name}</div>
+        <div className="lp-game-card-desc">{game.desc}</div>
+      </div>
+      <div className="lp-game-card-cta" style={{ color: game.color }}>
+        {game.tag === 'SOON' ? 'Coming soon' : 'Play now →'}
+      </div>
+    </div>
+  );
+}
+
+function GameCardAnim({ game }) {
+  if (game.anim === 'card-flip') {
+    return (
+      <div className="lp-anim-cards">
+        <div className="lp-card lp-card-back lp-card-1">
+          <div className="lp-card-inner">
+            <div className="lp-card-front"><span className="lp-suit-gold">A</span><span className="lp-suit-small">♠</span></div>
+            <div className="lp-card-back-face" />
+          </div>
+        </div>
+        <div className="lp-card lp-card-back lp-card-2">
+          <div className="lp-card-inner">
+            <div className="lp-card-front lp-red-card"><span>K</span><span className="lp-suit-small">♥</span></div>
+            <div className="lp-card-back-face" />
+          </div>
+        </div>
+        <div className="lp-card lp-card-back lp-card-3">
+          <div className="lp-card-inner">
+            <div className="lp-card-front"><span className="lp-suit-gold">Q</span><span className="lp-suit-small">♦</span></div>
+            <div className="lp-card-back-face" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+  if (game.anim === 'chip-stack') {
+    return (
+      <div className="lp-anim-chips">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className={`lp-chip lp-chip-${i}`} />
+        ))}
+      </div>
+    );
+  }
+  if (game.anim === 'coin-spin') {
+    return (
+      <div className="lp-anim-coin">
+        <div className="lp-coin">
+          <div className="lp-coin-face lp-coin-h">H</div>
+          <div className="lp-coin-face lp-coin-t">T</div>
+        </div>
+      </div>
+    );
+  }
+  if (game.anim === 'card-slide') {
+    return (
+      <div className="lp-anim-hilo">
+        <div className="lp-hilo-card lp-hilo-bot"><span className="lp-suit-gold">7</span><span className="lp-suit-small">♠</span></div>
+        <div className="lp-hilo-arrows">
+          <span className="lp-arrow lp-arrow-up">▲</span>
+          <span className="lp-arrow lp-arrow-down">▼</span>
+        </div>
+        <div className="lp-hilo-card lp-hilo-reveal"><span className="lp-red-card">J</span><span className="lp-suit-small lp-red-card">♥</span></div>
+      </div>
+    );
+  }
+  if (game.anim === 'two-cards') {
+    return (
+      <div className="lp-anim-acey">
+        <div className="lp-acey-card lp-acey-left"><span className="lp-suit-gold">2</span><span className="lp-suit-small">♣</span></div>
+        <div className="lp-acey-mid">
+          <div className="lp-acey-mid-label">between?</div>
+          <div className="lp-acey-mid-card lp-acey-reveal"><span>9</span><span className="lp-suit-small">♦</span></div>
+        </div>
+        <div className="lp-acey-card lp-acey-right"><span className="lp-red-card">K</span><span className="lp-suit-small lp-red-card">♥</span></div>
+      </div>
+    );
+  }
+  if (game.anim === 'reel-spin') {
+    const syms = ['7', '$', '♦', '★', '7'];
+    return (
+      <div className="lp-anim-slots">
+        {[0, 1, 2].map(col => (
+          <div key={col} className="lp-slot-reel">
+            <div className={`lp-slot-strip lp-strip-${col}`}>
+              {syms.map((s, i) => <div key={i} className="lp-slot-sym">{s}</div>)}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+  if (game.anim === 'wheel-spin') {
+    return (
+      <div className="lp-anim-roulette">
+        <div className="lp-wheel">
+          {[...Array(12)].map((_, i) => (
+            <div
+              key={i}
+              className={`lp-wheel-seg ${i % 2 === 0 ? 'lp-seg-red' : 'lp-seg-dark'}`}
+              style={{ transform: `rotate(${i * 30}deg)` }}
+            />
+          ))}
+          <div className="lp-wheel-center" />
+        </div>
+        <div className="lp-roulette-ball" />
+      </div>
+    );
+  }
+  return null;
+}
+
+export default function LandingPage() {
+  const { openModal } = useContext(ModalContext);
+  const howRef = useRef(null);
+
+  const scrollToHow = (e) => {
+    e.preventDefault();
+    howRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const handleCTA = () => openModal('signup');
+
+  return (
+    <div className="lp-root">
+
+      {/* ── NAV ────────────────────────────────────────────────── */}
+      <nav className="lp-nav">
+        <div className="lp-nav-inner">
+          <div className="lp-nav-brand">
+            <img src={socialstakesCards} alt="Social Stakes" className="lp-nav-logo" />
+            <span className="lp-nav-name">SOCIAL <span className="lp-gold">STAKES</span></span>
+          </div>
+          <div className="lp-nav-actions">
+            <button className="lp-btn-ghost" onClick={() => openModal('login')}>Sign In</button>
+            <button className="lp-btn-gold" onClick={handleCTA}>Sign Up Free</button>
+          </div>
+        </div>
+      </nav>
+
+      {/* ── HERO ───────────────────────────────────────────────── */}
+      <section className="lp-hero">
+        <div className="lp-hero-bg-grid" />
+        <div className="lp-hero-glow" />
+        <div className="lp-hero-inner">
+          <div className="lp-hero-eyebrow">
+            <span className="lp-eyebrow-dot" />
+            No real money. No house edge tricks.
+          </div>
+          <h1 className="lp-hero-headline">
+            Provably fair<br />
+            <span className="lp-gold">blackjack</span> with friends
+          </h1>
+          <p className="lp-hero-sub">
+            Verify every hand. Bring your crew. Play for fun —<br className="lp-br-desk" />
+            not for your rent money.
+          </p>
+          <div className="lp-hero-ctas">
+            <button className="lp-btn-hero-primary" onClick={handleCTA}>
+              Play Free Now
+              <span className="lp-btn-arrow">→</span>
+            </button>
+            <button className="lp-btn-hero-ghost" onClick={scrollToHow}>
+              How fairness works
+            </button>
+          </div>
+          <div className="lp-hero-chips">
+            <img src={goldChip} alt="" className="lp-chip-float lp-cf-1" aria-hidden />
+            <img src={goldChip} alt="" className="lp-chip-float lp-cf-2" aria-hidden />
+            <img src={goldChip} alt="" className="lp-chip-float lp-cf-3" aria-hidden />
+          </div>
+          <div className="lp-hero-stats">
+            <div className="lp-stat"><span className="lp-stat-n lp-gold">$0</span><span className="lp-stat-l">real money</span></div>
+            <div className="lp-stat-divider" />
+            <div className="lp-stat"><span className="lp-stat-n lp-gold">8</span><span className="lp-stat-l">games</span></div>
+            <div className="lp-stat-divider" />
+            <div className="lp-stat"><span className="lp-stat-n lp-gold">100%</span><span className="lp-stat-l">verifiable</span></div>
+          </div>
+        </div>
+        <div className="lp-hero-cards-deco">
+          <div className="lp-deco-card lp-deco-c1"><span className="lp-suit-gold">A</span><span className="lp-deco-suit">♠</span></div>
+          <div className="lp-deco-card lp-deco-c2 lp-red-card"><span>K</span><span className="lp-deco-suit">♥</span></div>
+          <div className="lp-deco-card lp-deco-c3"><span className="lp-suit-gold">Q</span><span className="lp-deco-suit">♦</span></div>
+          <div className="lp-deco-card lp-deco-c4 lp-red-card"><span>J</span><span className="lp-deco-suit">♣</span></div>
+        </div>
+      </section>
+
+      {/* ── GAME PREVIEW ROW ─────────────────────────────────── */}
+      <section className="lp-games">
+        <div className="lp-section-inner">
+          <div className="lp-section-header">
+            <h2 className="lp-section-title">Eight ways to play</h2>
+            <p className="lp-section-sub">Live tables, solo demos, and more on the way.</p>
+          </div>
+          <div className="lp-games-grid">
+            {GAMES.map(g => (
+              <GameCard key={g.id} game={g} onCTA={g.tag !== 'SOON' ? handleCTA : undefined} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── WHY IT'S DIFFERENT ───────────────────────────────── */}
+      <section className="lp-why">
+        <div className="lp-section-inner">
+          <div className="lp-section-header">
+            <h2 className="lp-section-title">Why Social Stakes is different</h2>
+          </div>
+          <div className="lp-why-grid">
+            <div className="lp-why-card">
+              <div className="lp-why-icon lp-why-icon-gold">
+                <span className="lp-icon-glyph">⧫</span>
+              </div>
+              <h3 className="lp-why-title">Provably Fair</h3>
+              <p className="lp-why-desc">
+                Every shuffle is seeded from a public Bitcoin block hash. After each hand, you get the seed — paste it into our verifier and confirm the cards were predetermined before the round started. No trust required.
+              </p>
+              <a href="#how" onClick={scrollToHow} className="lp-why-link lp-gold">See how it works →</a>
+            </div>
+            <div className="lp-why-card">
+              <div className="lp-why-icon lp-why-icon-blue">
+                <span className="lp-icon-glyph">◈</span>
+              </div>
+              <h3 className="lp-why-title">Friends First</h3>
+              <p className="lp-why-desc">
+                Invite friends to a private table, track your crew on the leaderboard, and trash-talk in real-time table chat. Built for Friday nights with people you actually know — not random strangers.
+              </p>
+            </div>
+            <div className="lp-why-card">
+              <div className="lp-why-icon lp-why-icon-green">
+                <span className="lp-icon-glyph">◉</span>
+              </div>
+              <h3 className="lp-why-title">No Money on the Line</h3>
+              <p className="lp-why-desc">
+                Everyone starts with $10,000 in demo chips. No deposits, no withdrawals, no gambling. When your bankroll hits zero we reset it — because this is about the game, not the grind.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── HOW IT WORKS ──────────────────────────────────────── */}
+      <section className="lp-how" id="how" ref={howRef}>
+        <div className="lp-section-inner">
+          <div className="lp-section-header">
+            <h2 className="lp-section-title">How it works</h2>
+            <p className="lp-section-sub">Up and playing in under two minutes.</p>
+          </div>
+          <div className="lp-steps">
+            {STEPS.map((step, i) => (
+              <div className="lp-step" key={i}>
+                <div className="lp-step-num lp-gold">{step.num}</div>
+                <div className="lp-step-connector" />
+                <div className="lp-step-body">
+                  <div className="lp-step-label">{step.label}</div>
+                  <div className="lp-step-desc">{step.desc}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Provably fair detail */}
+          <div className="lp-pf-box">
+            <div className="lp-pf-header">
+              <span className="lp-pf-badge lp-gold">Provably Fair — how it works</span>
+            </div>
+            <div className="lp-pf-steps">
+              <div className="lp-pf-step">
+                <div className="lp-pf-icon">1</div>
+                <div className="lp-pf-text">Before dealing, we hash a Bitcoin block number to generate a deck seed.</div>
+              </div>
+              <div className="lp-pf-arrow">→</div>
+              <div className="lp-pf-step">
+                <div className="lp-pf-icon">2</div>
+                <div className="lp-pf-text">Cards are drawn deterministically from that seed — the order is fixed before you bet.</div>
+              </div>
+              <div className="lp-pf-arrow">→</div>
+              <div className="lp-pf-step">
+                <div className="lp-pf-icon">3</div>
+                <div className="lp-pf-text">After the hand, we reveal the seed. You can reproduce the exact shuffle yourself.</div>
+              </div>
+            </div>
+            <button className="lp-btn-ghost lp-pf-cta" onClick={handleCTA}>
+              Try the verifier after your first hand →
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* ── SOCIAL PROOF ─────────────────────────────────────── */}
+      <section className="lp-quotes">
+        <div className="lp-section-inner">
+          <div className="lp-section-header">
+            <h2 className="lp-section-title">What players say</h2>
+            <p className="lp-section-sub lp-quotes-note">Illustrative quotes — the feeling is real even if the names aren't.</p>
+          </div>
+          <div className="lp-quotes-grid">
+            {QUOTES.map((q, i) => (
+              <div className="lp-quote-card" key={i}>
+                <div className="lp-quote-mark lp-gold">"</div>
+                <p className="lp-quote-text">{q.text}</p>
+                <div className="lp-quote-attr">
+                  <div className="lp-quote-avatar">{q.name[0]}</div>
+                  <div>
+                    <div className="lp-quote-name">{q.name}</div>
+                    <div className="lp-quote-sub">{q.sub}</div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── FINAL CTA ────────────────────────────────────────── */}
+      <section className="lp-final-cta">
+        <div className="lp-final-glow" />
+        <div className="lp-section-inner lp-final-inner">
+          <h2 className="lp-final-title">
+            Ready to play<br /><span className="lp-gold">the honest way?</span>
+          </h2>
+          <p className="lp-final-sub">No credit card. No real money. No catch.</p>
+          <button className="lp-btn-hero-primary lp-final-btn" onClick={handleCTA}>
+            Start Playing Free
+            <span className="lp-btn-arrow">→</span>
+          </button>
+          <div className="lp-final-footnote">No credit card &nbsp;·&nbsp; No real money &nbsp;·&nbsp; Cancel anytime</div>
+        </div>
+      </section>
+
+      {/* ── FOOTER ───────────────────────────────────────────── */}
+      <footer className="lp-footer">
+        <div className="lp-footer-inner">
+          <div className="lp-footer-brand">
+            <img src={socialstakesCards} alt="Social Stakes" className="lp-footer-logo" />
+            <span className="lp-footer-name">Social Stakes</span>
+          </div>
+          <div className="lp-footer-links">
+            <button className="lp-footer-link" onClick={() => openModal('login')}>Sign In</button>
+            <button className="lp-footer-link" onClick={handleCTA}>Sign Up</button>
+          </div>
+          <div className="lp-footer-note">Demo platform only. No real gambling. All chips are fictional.</div>
+        </div>
+      </footer>
+
+    </div>
+  );
+}

--- a/frontend/src/components/LandingPage/index.js
+++ b/frontend/src/components/LandingPage/index.js
@@ -283,13 +283,6 @@ export default function LandingPage() {
             <img src={goldChip} alt="" className="lp-chip-float lp-cf-2" aria-hidden />
             <img src={goldChip} alt="" className="lp-chip-float lp-cf-3" aria-hidden />
           </div>
-          <div className="lp-hero-stats">
-            <div className="lp-stat"><span className="lp-stat-n lp-gold">$0</span><span className="lp-stat-l">real money</span></div>
-            <div className="lp-stat-divider" />
-            <div className="lp-stat"><span className="lp-stat-n lp-gold">8</span><span className="lp-stat-l">games</span></div>
-            <div className="lp-stat-divider" />
-            <div className="lp-stat"><span className="lp-stat-n lp-gold">100%</span><span className="lp-stat-l">verifiable</span></div>
-          </div>
         </div>
         <div className="lp-hero-cards-deco">
           <div className="lp-deco-card lp-deco-c1"><span className="lp-suit-gold">A</span><span className="lp-deco-suit">♠</span></div>

--- a/frontend/src/components/games/Blackjack.js
+++ b/frontend/src/components/games/Blackjack.js
@@ -1,0 +1,741 @@
+import React, { useState, useRef, useEffect, useMemo } from 'react';
+import Navigation from '../Navigation';
+
+// ── deck primitives ──────────────────────────────────────────────
+const SUITS = ['h', 'd', 'c', 's'];
+const RANKS = ['2','3','4','5','6','7','8','9','T','J','Q','K','A'];
+const SUIT_SYM = { h:'♥', d:'♦', c:'♣', s:'♠' };
+const RANK_DISP = { T:'10' };
+
+function makeShoe(decks = 6) {
+  const shoe = [];
+  for (let n = 0; n < decks; n++) {
+    for (const r of RANKS) for (const s of SUITS) shoe.push(r + s);
+  }
+  return shoe;
+}
+function shuffle(d) {
+  const a = [...d];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+function cardRank(c) { return c[0]; }
+function cardValue(r) {
+  if (r === 'A') return 11;
+  if (r === 'T' || r === 'J' || r === 'Q' || r === 'K') return 10;
+  return parseInt(r, 10);
+}
+function handValue(cards) {
+  let total = 0, aces = 0;
+  for (const c of cards) {
+    const r = cardRank(c);
+    if (r === 'A') { aces++; total += 11; }
+    else total += cardValue(r);
+  }
+  while (total > 21 && aces > 0) { total -= 10; aces--; }
+  return { total, soft: aces > 0 };
+}
+function isBlackjack(cards) {
+  return cards.length === 2 && handValue(cards).total === 21;
+}
+
+// ── card visuals ─────────────────────────────────────────────────
+const CARD_DIMS = { sm: [60, 86, 11, 24], md: [72, 104, 13, 28] };
+
+function CardFace({ card, size = 'sm' }) {
+  const [w, h, fs, cs] = CARD_DIMS[size];
+  const isRed = card[1] === 'h' || card[1] === 'd';
+  const rank = RANK_DISP[card[0]] || card[0];
+  const suit = SUIT_SYM[card[1]];
+  return (
+    <div style={{
+      width: w, height: h, borderRadius: 8, background: '#fafaf6',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
+      border: '1px solid rgba(0,0,0,0.08)',
+      position: 'relative', padding: 6, flexShrink: 0,
+      color: isRed ? '#d63a3a' : '#111', fontWeight: 800,
+    }}>
+      <div style={{ fontSize: fs, lineHeight: 1 }}>{rank}{suit}</div>
+      <div style={{
+        position: 'absolute', top: '50%', left: '50%',
+        transform: 'translate(-50%,-50%)', fontSize: cs,
+      }}>{suit}</div>
+      <div style={{
+        position: 'absolute', bottom: 6, right: 6,
+        fontSize: fs, transform: 'rotate(180deg)', lineHeight: 1,
+      }}>{rank}{suit}</div>
+    </div>
+  );
+}
+function CardBack({ size = 'sm' }) {
+  const [w, h] = CARD_DIMS[size];
+  return (
+    <div style={{
+      width: w, height: h, borderRadius: 8,
+      background: 'repeating-linear-gradient(45deg,#2e63b8 0 4px,#224b8c 4px 8px)',
+      border: '1px solid rgba(0,0,0,0.18)',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.5)', flexShrink: 0,
+    }} />
+  );
+}
+function CardSlot({ size = 'sm' }) {
+  const [w, h] = CARD_DIMS[size];
+  return (
+    <div style={{
+      width: w, height: h, borderRadius: 8,
+      border: '1.5px dashed var(--ss-border)', opacity: 0.3, flexShrink: 0,
+    }} />
+  );
+}
+
+// ── component ────────────────────────────────────────────────────
+export default function Blackjack() {
+  const [bankroll,  setBankroll]  = useState(1000);
+  const [bet,       setBet]       = useState(25);
+  const [phase,     setPhase]     = useState('idle'); // idle | player | dealer | insurance | end
+  const [shoe,      setShoe]      = useState(() => shuffle(makeShoe()));
+  const [hands,     setHands]     = useState([]); // [{cards,bet,doubled,stood,busted,resolved,result,delta,fromSplitAce}]
+  const [activeIdx, setActiveIdx] = useState(0);
+  const [dealer,    setDealer]    = useState([]);
+  const [hideHole,  setHideHole]  = useState(true);
+  const [insurance, setInsurance] = useState(0);
+  const [message,   setMessage]   = useState('Set your bet and deal.');
+  const [history,   setHistory]   = useState([]);
+
+  const shoeRef = useRef(shoe);
+  useEffect(() => { shoeRef.current = shoe; }, [shoe]);
+  // Guards against double-clicks racing async state transitions.
+  const actingRef = useRef(false);
+  const phaseRef  = useRef('idle');
+  useEffect(() => { phaseRef.current = phase; }, [phase]);
+
+  // pull N cards from shoe, returns [drawn, remaining]
+  const draw = (n) => {
+    const s = shoeRef.current;
+    const drawn = s.slice(0, n);
+    const rest = s.slice(n);
+    shoeRef.current = rest;
+    setShoe(rest);
+    return drawn;
+  };
+
+  // reshuffle if the shoe drops below ~25% capacity
+  const ensureShoe = () => {
+    if (shoeRef.current.length < 60) {
+      const fresh = shuffle(makeShoe());
+      shoeRef.current = fresh;
+      setShoe(fresh);
+    }
+  };
+
+  // ── deal ─────────────────────────────────────────────────────────
+  const deal = () => {
+    if (bet <= 0 || bet > bankroll) return;
+    ensureShoe();
+    // Deal 4 cards: player, dealer, player, dealer
+    const drawn = draw(4);
+    const playerCards = [drawn[0], drawn[2]];
+    const dealerCards = [drawn[1], drawn[3]];
+
+    setBankroll(b => b - bet);
+    setHands([{
+      cards: playerCards, bet, doubled: false, stood: false,
+      busted: false, resolved: false, result: null, delta: 0, fromSplitAce: false,
+    }]);
+    setActiveIdx(0);
+    setDealer(dealerCards);
+    setHideHole(true);
+    setInsurance(0);
+
+    const playerBJ = isBlackjack(playerCards);
+    const dealerUp = dealerCards[0];
+    const dealerBJ = isBlackjack(dealerCards);
+
+    // Offer insurance when dealer up-card is Ace and player does not have BJ
+    if (cardRank(dealerUp) === 'A' && !playerBJ && bankroll - bet >= Math.floor(bet / 2)) {
+      setPhase('insurance');
+      setMessage('Dealer shows an Ace. Insurance?');
+      return;
+    }
+
+    // Dealer ten-up: peek for blackjack quietly
+    if (dealerBJ) {
+      setHideHole(false);
+      if (playerBJ) {
+        // push
+        finalizeRound(playerCards, dealerCards, [{
+          cards: playerCards, bet, doubled: false, stood: true, busted: false,
+          resolved: false, result: null, delta: 0, fromSplitAce: false, blackjack: true,
+        }], 0);
+        return;
+      }
+      finalizeRound(playerCards, dealerCards, [{
+        cards: playerCards, bet, doubled: false, stood: true, busted: false,
+        resolved: false, result: null, delta: 0, fromSplitAce: false,
+      }], 0, /*dealerBlackjack*/ true);
+      return;
+    }
+
+    if (playerBJ) {
+      // instant 3:2 win
+      finalizeRound(playerCards, dealerCards, [{
+        cards: playerCards, bet, doubled: false, stood: true, busted: false,
+        resolved: false, result: null, delta: 0, fromSplitAce: false, blackjack: true,
+      }], 0);
+      return;
+    }
+
+    setPhase('player');
+    setMessage('Your move.');
+  };
+
+  // ── insurance ────────────────────────────────────────────────────
+  const takeInsurance = (yes) => {
+    const ins = yes ? Math.floor(bet / 2) : 0;
+    setInsurance(ins);
+    if (ins > 0) setBankroll(b => b - ins);
+
+    const dealerBJ = isBlackjack(dealer);
+    if (dealerBJ) {
+      setHideHole(false);
+      const playerBJ = isBlackjack(hands[0].cards);
+      finalizeRound(hands[0].cards, dealer, hands, ins, /*dealerBlackjack*/ true, playerBJ);
+      return;
+    }
+
+    // Dealer doesn't have BJ — insurance lost (already deducted), continue
+    setPhase('player');
+    setMessage(ins > 0 ? 'No dealer blackjack. Insurance lost.' : 'Your move.');
+  };
+
+  // ── player actions ───────────────────────────────────────────────
+  const updateHand = (idx, patch) => {
+    setHands(hs => hs.map((h, i) => i === idx ? { ...h, ...patch } : h));
+  };
+
+  const advanceAfterAction = (updatedHands, idx) => {
+    const h = updatedHands[idx];
+    const total = handValue(h.cards).total;
+    const finished = h.busted || h.stood || h.doubled || total >= 21;
+    if (!finished) return;
+
+    if (idx + 1 < updatedHands.length) {
+      setActiveIdx(idx + 1);
+      const next = updatedHands[idx + 1];
+      if (next.stood || next.busted || handValue(next.cards).total >= 21) {
+        setTimeout(() => advanceAfterAction(updatedHands, idx + 1), 200);
+      } else {
+        setMessage(`Hand ${idx + 2} — your move.`);
+      }
+    } else {
+      runDealer(updatedHands);
+    }
+  };
+
+  const hit = () => {
+    if (phaseRef.current !== 'player' || actingRef.current) return;
+    actingRef.current = true;
+    const idx = activeIdx;
+    const [c] = draw(1);
+    const newCards = [...hands[idx].cards, c];
+    const v = handValue(newCards).total;
+    const busted = v > 21;
+    const next = hands.map((h, i) => i === idx ? {
+      ...h, cards: newCards, busted, stood: !busted && v === 21,
+    } : h);
+    setHands(next);
+    if (busted) {
+      setMessage(`Hand ${idx + 1} busts at ${v}.`);
+    } else if (v === 21) {
+      setMessage('21!');
+    }
+    setTimeout(() => {
+      advanceAfterAction(next, idx);
+      actingRef.current = false;
+    }, 250);
+  };
+
+  const stand = () => {
+    if (phaseRef.current !== 'player' || actingRef.current) return;
+    actingRef.current = true;
+    const idx = activeIdx;
+    const next = hands.map((h, i) => i === idx ? { ...h, stood: true } : h);
+    setHands(next);
+    setTimeout(() => {
+      advanceAfterAction(next, idx);
+      actingRef.current = false;
+    }, 200);
+  };
+
+  const canDouble = () => {
+    if (phase !== 'player') return false;
+    const h = hands[activeIdx];
+    if (!h || h.cards.length !== 2 || h.fromSplitAce) return false;
+    return bankroll >= h.bet;
+  };
+
+  const doubleDown = () => {
+    if (!canDouble() || actingRef.current) return;
+    actingRef.current = true;
+    const idx = activeIdx;
+    const h = hands[idx];
+    setBankroll(b => b - h.bet);
+    const [c] = draw(1);
+    const newCards = [...h.cards, c];
+    const v = handValue(newCards).total;
+    const next = hands.map((hh, i) => i === idx ? {
+      ...hh, cards: newCards, bet: hh.bet * 2, doubled: true,
+      busted: v > 21, stood: true,
+    } : hh);
+    setHands(next);
+    setMessage(v > 21 ? `Doubled — busts at ${v}.` : `Doubled — stands at ${v}.`);
+    setTimeout(() => {
+      advanceAfterAction(next, idx);
+      actingRef.current = false;
+    }, 350);
+  };
+
+  const canSplit = () => {
+    if (phase !== 'player') return false;
+    const h = hands[activeIdx];
+    if (!h || h.cards.length !== 2) return false;
+    if (cardRank(h.cards[0]) !== cardRank(h.cards[1])) return false;
+    if (hands.length >= 4) return false;
+    return bankroll >= h.bet;
+  };
+
+  const split = () => {
+    if (!canSplit() || actingRef.current) return;
+    actingRef.current = true;
+    const idx = activeIdx;
+    const h = hands[idx];
+    setBankroll(b => b - h.bet);
+
+    const isAce = cardRank(h.cards[0]) === 'A';
+    // Each split hand gets one fresh card immediately
+    const [card1, card2] = draw(2);
+    const handA = {
+      cards: [h.cards[0], card1],
+      bet: h.bet, doubled: false, stood: isAce, busted: false,
+      resolved: false, result: null, delta: 0, fromSplitAce: isAce,
+    };
+    const handB = {
+      cards: [h.cards[1], card2],
+      bet: h.bet, doubled: false, stood: isAce, busted: false,
+      resolved: false, result: null, delta: 0, fromSplitAce: isAce,
+    };
+
+    const next = [
+      ...hands.slice(0, idx),
+      handA,
+      handB,
+      ...hands.slice(idx + 1),
+    ];
+    setHands(next);
+
+    if (isAce) {
+      setMessage('Split Aces — one card each, auto-stand.');
+      setTimeout(() => { runDealer(next); actingRef.current = false; }, 400);
+      return;
+    }
+
+    setMessage('Hand 1 — your move.');
+    if (handValue(handA.cards).total === 21) {
+      const auto = next.map((hh, i) => i === idx ? { ...hh, stood: true } : hh);
+      setHands(auto);
+      setTimeout(() => { advanceAfterAction(auto, idx); actingRef.current = false; }, 250);
+    } else {
+      actingRef.current = false;
+    }
+  };
+
+  // ── dealer ───────────────────────────────────────────────────────
+  const runDealer = (finalHands) => {
+    setPhase('dealer');
+    setHideHole(false);
+
+    const allBusted = finalHands.every(h => h.busted || handValue(h.cards).total > 21);
+    if (allBusted) {
+      finalizeRound(null, dealer, finalHands, insurance);
+      return;
+    }
+
+    // Dealer hits until total >= 17 (stand on all 17)
+    let dCards = [...dealer];
+    const dealStep = () => {
+      const v = handValue(dCards).total;
+      if (v < 17) {
+        const [c] = draw(1);
+        dCards = [...dCards, c];
+        setDealer(dCards);
+        setTimeout(dealStep, 450);
+      } else {
+        finalizeRound(null, dCards, finalHands, insurance);
+      }
+    };
+    setTimeout(dealStep, 500);
+  };
+
+  // ── resolve hands ────────────────────────────────────────────────
+  const finalizeRound = (_unused, dealerCards, finalHands, insBet, dealerBlackjack = false, playerBlackjack = false) => {
+    const dVal = handValue(dealerCards).total;
+    const dBJ = dealerBlackjack || isBlackjack(dealerCards);
+    let totalDelta = 0;
+    let totalReturn = 0;
+
+    const resolved = finalHands.map(h => {
+      const pVal = handValue(h.cards).total;
+      const pBJ = (h.blackjack || isBlackjack(h.cards)) && !h.fromSplitAce;
+      let result, delta;
+      // Defensive: any hand over 21 is a loss regardless of stored flag (handles
+      // races where stand/bust flags get out of sync with cards).
+      if (h.busted || pVal > 21) {
+        result = 'loss'; delta = -h.bet;
+      } else if (pBJ && !dBJ) {
+        // 3:2 payout
+        result = 'blackjack';
+        delta = Math.floor(h.bet * 1.5);
+        totalReturn += h.bet + Math.floor(h.bet * 1.5); // original bet back + 1.5x
+      } else if (pBJ && dBJ) {
+        result = 'push'; delta = 0; totalReturn += h.bet;
+      } else if (dBJ) {
+        result = 'loss'; delta = -h.bet;
+      } else if (dVal > 21) {
+        result = 'win'; delta = h.bet; totalReturn += h.bet * 2;
+      } else if (pVal > dVal) {
+        result = 'win'; delta = h.bet; totalReturn += h.bet * 2;
+      } else if (pVal < dVal) {
+        result = 'loss'; delta = -h.bet;
+      } else {
+        result = 'push'; delta = 0; totalReturn += h.bet;
+      }
+      totalDelta += delta;
+      return { ...h, resolved: true, result, delta };
+    });
+
+    // Insurance pays 2:1 if dealer BJ
+    let insMsg = '';
+    if (insBet > 0) {
+      if (dBJ) {
+        totalReturn += insBet * 3; // bet back + 2x
+        totalDelta += insBet * 2;
+        insMsg = ` Insurance pays $${insBet * 2}.`;
+      } else {
+        totalDelta -= insBet;
+        insMsg = ` Insurance lost.`;
+      }
+    }
+
+    setHands(resolved);
+    if (totalReturn > 0) setBankroll(b => b + totalReturn);
+
+    // Build message
+    const lines = resolved.map((h, i) => {
+      const tag = h.result === 'win' ? '✓ Win'
+                : h.result === 'loss' ? '✗ Loss'
+                : h.result === 'blackjack' ? '★ Blackjack'
+                : '⇌ Push';
+      return resolved.length > 1 ? `H${i + 1}: ${tag}` : tag;
+    });
+    const headline = totalDelta > 0 ? `+$${totalDelta}` : totalDelta < 0 ? `-$${Math.abs(totalDelta)}` : 'Push';
+    setMessage(`${headline} · ${lines.join(' · ')}${insMsg}`);
+
+    setHistory(h => [{
+      delta: totalDelta,
+      hands: resolved.map(r => ({ result: r.result, total: handValue(r.cards).total, bet: r.bet })),
+      dealerTotal: dVal,
+      dealerBlackjack: dBJ,
+    }, ...h].slice(0, 10));
+
+    setPhase('end');
+  };
+
+  // ── reset hand ───────────────────────────────────────────────────
+  const newHand = () => {
+    setHands([]);
+    setDealer([]);
+    setActiveIdx(0);
+    setHideHole(true);
+    setInsurance(0);
+    setPhase('idle');
+    setMessage('Set your bet and deal.');
+  };
+
+  const reload = () => {
+    setBankroll(1000);
+    setHands([]);
+    setDealer([]);
+    setActiveIdx(0);
+    setHideHole(true);
+    setInsurance(0);
+    setPhase('idle');
+    setMessage('Reloaded $1,000. Good luck!');
+  };
+
+  // ── derived ──────────────────────────────────────────────────────
+  const activeHand = hands[activeIdx];
+  const showActions = phase === 'player';
+
+  const dealerDisplayTotal = useMemo(() => {
+    if (!dealer.length) return null;
+    if (hideHole) {
+      const upRank = cardRank(dealer[0]);
+      const v = upRank === 'A' ? 11 : cardValue(upRank);
+      return v;
+    }
+    return handValue(dealer).total;
+  }, [dealer, hideHole]);
+
+  const resultColor = (r) =>
+    r === 'win' || r === 'blackjack' ? 'var(--ss-green)' :
+    r === 'loss' ? 'var(--ss-red)' :
+    r === 'push' ? 'var(--ss-text-dim)' : 'var(--ss-text-dim)';
+
+  // ── render ──────────────────────────────────────────────────────
+  return (
+    <>
+      <Navigation />
+      <div className="ss-page">
+        <div className="ss-pill ss-pill-gold" style={{ marginBottom: 10 }}>Demo grade · Local shoe</div>
+        <h1 className="ss-h1">Blackjack</h1>
+        <p className="ss-sub">Heads-up vs the dealer. Blackjack pays 3:2 · Dealer stands on all 17 · 6-deck shoe.</p>
+
+        <div className="ss-side-grid">
+          {/* ── main game card ── */}
+          <div className="ss-card" style={{ padding: 20 }}>
+
+            {/* stats bar */}
+            <div style={{
+              display: 'flex', justifyContent: 'space-between',
+              alignItems: 'center', marginBottom: 14, flexWrap: 'wrap', gap: 10,
+            }}>
+              <div>
+                <div className="ss-stat-label">Bankroll</div>
+                <div style={{ fontSize: 22, fontWeight: 700 }}>${bankroll.toLocaleString()}</div>
+              </div>
+              <div>
+                <div className="ss-stat-label">Bet</div>
+                <div style={{ fontSize: 22, fontWeight: 700, color: 'var(--ss-gold)' }}>
+                  ${(hands.length > 0 ? hands.reduce((s, h) => s + h.bet, 0) : bet).toLocaleString()}
+                </div>
+              </div>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span className="ss-stat-label" style={{ margin: 0 }}>Wager</span>
+                  <input type="number" value={bet}
+                    onChange={e => setBet(Math.max(1, parseInt(e.target.value) || 0))}
+                    disabled={phase !== 'idle'}
+                    className="ss-mono"
+                    style={{ width: 80, padding: '5px 8px', borderRadius: 8, background: 'var(--ss-bg-soft)', border: '1px solid var(--ss-border)', color: 'var(--ss-text)', fontSize: 14 }} />
+                </div>
+                {phase === 'idle' && (
+                  <div style={{ display: 'flex', gap: 4 }}>
+                    {[10, 25, 100, 500].map(v => (
+                      <button key={v} className="ss-btn" onClick={() => setBet(Math.min(v, bankroll))}
+                        style={{ minWidth: 38, height: 28, fontSize: 11, padding: '0 6px' }}>
+                        ${v}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* dealer */}
+            <div style={{ marginBottom: 14 }}>
+              <div className="ss-stat-label" style={{ marginBottom: 6, textAlign: 'center' }}>
+                Dealer {dealerDisplayTotal != null && `· ${dealerDisplayTotal}${hideHole ? '+' : ''}`}
+              </div>
+              <div style={{ display: 'flex', gap: 6, justifyContent: 'center', flexWrap: 'wrap', minHeight: 86 }}>
+                {dealer.length === 0 ? (
+                  <>
+                    <CardSlot size="sm" />
+                    <CardSlot size="sm" />
+                  </>
+                ) : dealer.map((c, i) => {
+                  if (i === 1 && hideHole) return <CardBack key={i} size="sm" />;
+                  return <CardFace key={i} card={c} size="sm" />;
+                })}
+              </div>
+            </div>
+
+            {/* player hands */}
+            <div style={{ marginBottom: 14 }}>
+              <div className="ss-stat-label" style={{ marginBottom: 6, textAlign: 'center' }}>You</div>
+              <div style={{ display: 'flex', gap: 16, justifyContent: 'center', flexWrap: 'wrap' }}>
+                {hands.length === 0 ? (
+                  <div style={{ display: 'flex', gap: 6 }}>
+                    <CardSlot size="sm" />
+                    <CardSlot size="sm" />
+                  </div>
+                ) : hands.map((h, i) => {
+                  const v = handValue(h.cards);
+                  const isActive = i === activeIdx && phase === 'player';
+                  return (
+                    <div key={i} style={{
+                      padding: 8, borderRadius: 10,
+                      border: isActive ? '2px solid var(--ss-gold)' : '1px solid var(--ss-border-soft)',
+                      background: isActive ? 'rgba(255,200,80,0.06)' : 'transparent',
+                    }}>
+                      <div style={{ display: 'flex', gap: 6 }}>
+                        {h.cards.map((c, j) => <CardFace key={j} card={c} size="sm" />)}
+                      </div>
+                      <div style={{
+                        marginTop: 5, fontSize: 11, textAlign: 'center', fontWeight: 700,
+                        color: h.resolved ? resultColor(h.result)
+                             : h.busted ? 'var(--ss-red)'
+                             : 'var(--ss-text-dim)',
+                      }}>
+                        {v.total}{v.soft && v.total <= 21 ? ' soft' : ''}
+                        {h.doubled && ' · Doubled'}
+                        {h.resolved && h.result === 'blackjack' && ' · BJ'}
+                        {h.resolved && ` · ${h.result === 'win' ? '+' : h.result === 'loss' ? '-' : ''}$${Math.abs(h.delta)}`}
+                        {' · '}${h.bet}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* message */}
+            <div style={{
+              textAlign: 'center', marginBottom: 14,
+              color: phase === 'end' ? 'var(--ss-text)' : 'var(--ss-text-dim)',
+              fontWeight: phase === 'end' ? 700 : 400, fontSize: 14, minHeight: 20,
+            }}>
+              {message}
+            </div>
+
+            {/* action buttons */}
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+              {phase === 'idle' && (
+                <button className="ss-btn ss-btn-primary"
+                  onClick={deal} disabled={bet > bankroll || bet <= 0}
+                  style={{ minWidth: 140, height: 44, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+                  Deal
+                </button>
+              )}
+
+              {phase === 'insurance' && (
+                <>
+                  <button className="ss-btn ss-btn-primary" onClick={() => takeInsurance(true)}
+                    style={{ minWidth: 130, height: 44, fontSize: 13, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+                    Insurance ${Math.floor(bet / 2)}
+                  </button>
+                  <button className="ss-btn" onClick={() => takeInsurance(false)}
+                    style={{ minWidth: 110, height: 44, fontSize: 13, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+                    No Insurance
+                  </button>
+                </>
+              )}
+
+              {showActions && (
+                <>
+                  <button className="ss-btn ss-btn-primary" onClick={hit}
+                    style={{ minWidth: 90, height: 44, fontSize: 14, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+                    Hit
+                  </button>
+                  <button className="ss-btn" onClick={stand}
+                    style={{ minWidth: 90, height: 44, fontSize: 14, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+                    Stand
+                  </button>
+                  <button className="ss-btn" onClick={doubleDown} disabled={!canDouble()}
+                    style={{ minWidth: 90, height: 44, fontSize: 14, letterSpacing: '0.06em', textTransform: 'uppercase', opacity: canDouble() ? 1 : 0.4 }}>
+                    Double
+                  </button>
+                  <button className="ss-btn" onClick={split} disabled={!canSplit()}
+                    style={{ minWidth: 90, height: 44, fontSize: 14, letterSpacing: '0.06em', textTransform: 'uppercase', opacity: canSplit() ? 1 : 0.4 }}>
+                    Split
+                  </button>
+                </>
+              )}
+
+              {phase === 'dealer' && (
+                <div style={{ color: 'var(--ss-text-muted)', fontStyle: 'italic', alignSelf: 'center' }}>
+                  Dealer playing…
+                </div>
+              )}
+
+              {phase === 'end' && bankroll > 0 && (
+                <button className="ss-btn ss-btn-primary" onClick={newHand}
+                  style={{ minWidth: 140, height: 44, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+                  New Hand
+                </button>
+              )}
+
+              {phase === 'end' && bankroll <= 0 && (
+                <button className="ss-btn" onClick={reload}
+                  style={{ minWidth: 160, height: 44, fontSize: 13, textTransform: 'uppercase' }}>
+                  Reload $1,000
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* ── sidebar ── */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {/* history */}
+            <div className="ss-card">
+              <div className="ss-stat-label" style={{ marginBottom: 10 }}>Recent hands</div>
+              {history.length === 0 ? (
+                <div style={{ color: 'var(--ss-text-muted)', fontSize: 13 }}>No hands yet.</div>
+              ) : history.map((h, i) => (
+                <div key={i} style={{
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
+                  padding: '7px 0', borderBottom: '1px solid var(--ss-border-soft)', fontSize: 13,
+                }}>
+                  <div>
+                    <div style={{
+                      fontWeight: 600,
+                      color: h.delta > 0 ? 'var(--ss-green)'
+                           : h.delta < 0 ? 'var(--ss-red)'
+                           : 'var(--ss-text-dim)',
+                    }}>
+                      {h.delta > 0 ? '✓ Win' : h.delta < 0 ? '✗ Loss' : '⇌ Push'}
+                    </div>
+                    <div style={{ fontSize: 11, color: 'var(--ss-text-muted)', marginTop: 2 }}>
+                      Dealer {h.dealerTotal}{h.dealerBlackjack ? ' · BJ' : ''}
+                    </div>
+                  </div>
+                  <span className="ss-mono" style={{
+                    color: h.delta > 0 ? 'var(--ss-green)' : h.delta < 0 ? 'var(--ss-red)' : 'var(--ss-text-muted)',
+                    fontWeight: 600,
+                  }}>
+                    {h.delta > 0 ? '+' : h.delta === 0 ? '±' : '-'}${Math.abs(h.delta)}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {/* rules */}
+            <div className="ss-card">
+              <div className="ss-stat-label" style={{ marginBottom: 8 }}>Rules</div>
+              {[
+                ['Blackjack', 'Pays 3:2'],
+                ['Insurance', 'Pays 2:1'],
+                ['Dealer', 'Stands on all 17'],
+                ['Double', 'Any first 2 cards'],
+                ['Split', 'Same rank only'],
+                ['Split Aces', 'One card each'],
+                ['Shoe', '6 decks'],
+              ].map(([name, desc]) => (
+                <div key={name} style={{
+                  display: 'flex', justifyContent: 'space-between',
+                  padding: '3px 0', fontSize: 11,
+                  borderBottom: '1px solid var(--ss-border-soft)',
+                }}>
+                  <span style={{ color: 'var(--ss-text-dim)', fontWeight: 600 }}>{name}</span>
+                  <span style={{ color: 'var(--ss-text-muted)' }}>{desc}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/games/HoldEm.js
+++ b/frontend/src/components/games/HoldEm.js
@@ -1,0 +1,525 @@
+import React, { useState, useRef, useMemo } from 'react';
+import { Hand } from 'pokersolver';
+import Navigation from '../Navigation';
+
+// ── deck primitives ──────────────────────────────────────────────
+const SUITS  = ['h', 'd', 'c', 's'];
+const RANKS  = ['2','3','4','5','6','7','8','9','T','J','Q','K','A'];
+const SUIT_SYM  = { h:'♥', d:'♦', c:'♣', s:'♠' };
+const RANK_DISP = { T:'10' };
+
+function makeDeck() {
+  const d = [];
+  for (const r of RANKS) for (const s of SUITS) d.push(r + s);
+  return d;
+}
+function shuffle(d) {
+  const a = [...d];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+function rankIdx(c) { return RANKS.indexOf(c[0]); }
+
+// ── hand-strength helpers ─────────────────────────────────────────
+function preflopStrength(cards) {
+  const r1 = rankIdx(cards[0]), r2 = rankIdx(cards[1]);
+  const suited = cards[0][1] === cards[1][1];
+  const paired = cards[0][0] === cards[1][0];
+  if (paired) return 0.5 + (Math.max(r1, r2) / 12) * 0.5;
+  let s = (r1 + r2) / 24;
+  if (suited) s += 0.08;
+  return Math.min(1, Math.max(0, s));
+}
+function postflopStrength(hole, community) {
+  if (community.length < 3) return preflopStrength(hole);
+  try { return (10 - Hand.solve([...hole, ...community]).rank) / 9; }
+  catch { return 0.3; }
+}
+function botDecide(strength) {
+  if (Math.random() < 0.12) return 'call'; // bluff
+  if (strength >= 0.65) return Math.random() < 0.93 ? 'call' : 'fold';
+  if (strength >= 0.40) return Math.random() < 0.60 ? 'call' : 'fold';
+  if (strength >= 0.25) return Math.random() < 0.32 ? 'call' : 'fold';
+  return Math.random() < 0.10 ? 'call' : 'fold';
+}
+
+// ── card visuals ─────────────────────────────────────────────────
+// sm = 60×86, md = 72×104
+const CARD_DIMS = { sm: [60, 86, 11, 24], md: [72, 104, 13, 28] };
+
+function CardFace({ card, size = 'sm' }) {
+  const [w, h, fs, cs] = CARD_DIMS[size];
+  const isRed = card[1] === 'h' || card[1] === 'd';
+  const rank   = RANK_DISP[card[0]] || card[0];
+  const suit   = SUIT_SYM[card[1]];
+  return (
+    <div style={{
+      width: w, height: h, borderRadius: 8, background: '#fafaf6',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.5)',
+      border: '1px solid rgba(0,0,0,0.08)',
+      position: 'relative', padding: 6, flexShrink: 0,
+      color: isRed ? '#d63a3a' : '#111', fontWeight: 800,
+      transition: 'transform 0.15s',
+    }}>
+      <div style={{ fontSize: fs, lineHeight: 1 }}>{rank}{suit}</div>
+      <div style={{
+        position: 'absolute', top: '50%', left: '50%',
+        transform: 'translate(-50%,-50%)', fontSize: cs,
+      }}>{suit}</div>
+      <div style={{
+        position: 'absolute', bottom: 6, right: 6,
+        fontSize: fs, transform: 'rotate(180deg)', lineHeight: 1,
+      }}>{rank}{suit}</div>
+    </div>
+  );
+}
+
+function CardBack({ size = 'sm' }) {
+  const [w, h] = CARD_DIMS[size];
+  return (
+    <div style={{
+      width: w, height: h, borderRadius: 8,
+      background: 'repeating-linear-gradient(45deg,#2e63b8 0 4px,#224b8c 4px 8px)',
+      border: '1px solid rgba(0,0,0,0.18)',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.5)', flexShrink: 0,
+    }} />
+  );
+}
+
+function CardSlot({ size = 'sm' }) {
+  const [w, h] = CARD_DIMS[size];
+  return (
+    <div style={{
+      width: w, height: h, borderRadius: 8,
+      border: '1.5px dashed var(--ss-border)', opacity: 0.3, flexShrink: 0,
+    }} />
+  );
+}
+
+// ── phase sequence ───────────────────────────────────────────────
+const PHASES   = ['preflop', 'flop', 'turn', 'river'];
+const PHASE_LBL = { preflop:'Pre-Flop', flop:'Flop', turn:'Turn', river:'River', end:'Showdown' };
+function nextPhase(p) {
+  const i = PHASES.indexOf(p);
+  return i < PHASES.length - 1 ? PHASES[i + 1] : 'showdown';
+}
+
+// ── component ────────────────────────────────────────────────────
+export default function HoldEm() {
+  const [bankroll,  setBankroll]  = useState(1000);
+  const [ante,      setAnte]      = useState(25);
+  const [streetBet, setStreetBet] = useState(25);
+  const [phase,     setPhase]     = useState('idle');
+  const [deck,      setDeck]      = useState([]);
+  const [playerHole,setPlayerHole]= useState([]);
+  const [botHole,   setBotHole]   = useState([]);
+  const [community, setCommunity] = useState([]);
+  const [pot,       setPot]       = useState(0);
+  const [result,    setResult]    = useState(null);   // { winner, delta, playerHand, botHand }
+  const [message,   setMessage]   = useState('Set your ante and deal a hand.');
+  const [botMsg,    setBotMsg]    = useState('');
+  const [revealBot, setRevealBot] = useState(false);
+  const [history,   setHistory]   = useState([]);
+
+  const investedRef = useRef(0);
+
+  // live hand hint for player after flop
+  const playerHandHint = useMemo(() => {
+    if (community.length >= 3 && playerHole.length === 2) {
+      try { return Hand.solve([...playerHole, ...community]).name; }
+      catch { return null; }
+    }
+    return null;
+  }, [community, playerHole]);
+
+  // ── game logic ─────────────────────────────────────────────────
+  const deal = () => {
+    if (ante <= 0 || ante > bankroll) return;
+    const d = shuffle(makeDeck());
+    investedRef.current = ante;
+    setBankroll(b => b - ante);
+    setPot(ante * 2);
+    setDeck(d.slice(4));
+    setPlayerHole([d[0], d[1]]);
+    setBotHole([d[2], d[3]]);
+    setCommunity([]);
+    setRevealBot(false);
+    setResult(null);
+    setBotMsg('');
+    setPhase('preflop');
+    setMessage('Pre-flop — see the flop free, or raise.');
+  };
+
+  const endHand = (winner, finalPot, phName, bhName) => {
+    setRevealBot(true);
+    const invested = investedRef.current;
+    let delta, msg;
+    if (winner === 'tie') {
+      delta = Math.floor(finalPot / 2) - invested;
+      msg = `Split pot — ${phName} ties ${bhName}.`;
+      setBankroll(b => b + Math.floor(finalPot / 2));
+    } else if (winner === 'player') {
+      delta = finalPot - invested;
+      msg = phName ? `You win $${finalPot}! ${phName} beats ${bhName}.`
+                   : `Bot folds — you win $${finalPot}!`;
+      setBankroll(b => b + finalPot);
+    } else {
+      delta = -invested;
+      msg = bhName ? `Bot wins with ${bhName}${phName ? ` vs your ${phName}` : ''}.`
+                   : 'You folded.';
+    }
+    setResult({ winner, delta, playerHand: phName, botHand: bhName });
+    setHistory(h => [{ winner, delta, playerHand: phName, botHand: bhName }, ...h].slice(0, 10));
+    setMessage(msg);
+    setPhase('end');
+  };
+
+  const doShowdown = (finalPot, comm) => {
+    const usePot  = finalPot ?? pot;
+    const useComm = comm ?? community;
+    const ph = Hand.solve([...playerHole, ...useComm]);
+    const bh = Hand.solve([...botHole,   ...useComm]);
+    const winners   = Hand.winners([ph, bh]);
+    const tie       = winners.length > 1;
+    const playerWins = !tie && winners[0] === ph;
+    endHand(tie ? 'tie' : playerWins ? 'player' : 'bot', usePot, ph.name, bh.name);
+  };
+
+  const advanceTo = (next, currentPot, comm) => {
+    const usePot = currentPot ?? pot;
+    if (next === 'flop') {
+      const newComm = [deck[0], deck[1], deck[2]];
+      setCommunity(newComm);
+      setPhase('flop');
+      setMessage('Flop — check or raise.');
+      setBotMsg('');
+    } else if (next === 'turn') {
+      const newComm = [...(comm ?? community), deck[3]];
+      setCommunity(newComm);
+      setPhase('turn');
+      setMessage('Turn — check or raise.');
+      setBotMsg('');
+    } else if (next === 'river') {
+      const newComm = [...(comm ?? community), deck[4]];
+      setCommunity(newComm);
+      setPhase('river');
+      setMessage('River — last chance to raise.');
+      setBotMsg('');
+    } else if (next === 'showdown') {
+      doShowdown(usePot, comm ?? community);
+    }
+  };
+
+  const playerFold = () => endHand('bot', pot, null, null);
+
+  const playerCheck = () => {
+    const next = nextPhase(phase);
+    setBotMsg('Bot checks.');
+    if (next === 'showdown') {
+      setTimeout(() => doShowdown(pot, community), 350);
+    } else {
+      setTimeout(() => advanceTo(next, pot, community), 350);
+    }
+  };
+
+  const playerBet = () => {
+    if (streetBet <= 0 || streetBet > bankroll) return;
+    const betAmt  = Math.min(streetBet, bankroll);
+    investedRef.current += betAmt;
+    setBankroll(b => b - betAmt);
+    const newPot  = pot + betAmt;
+
+    const strength = phase === 'preflop'
+      ? preflopStrength(botHole) : postflopStrength(botHole, community);
+    const decision = botDecide(strength);
+
+    if (decision === 'fold') {
+      setPot(newPot);
+      setBotMsg('Bot folds!');
+      setTimeout(() => endHand('player', newPot, null, null), 400);
+    } else {
+      const finalPot = newPot + betAmt;
+      setPot(finalPot);
+      setBotMsg('Bot calls.');
+      const next = nextPhase(phase);
+      if (next === 'showdown') {
+        setTimeout(() => doShowdown(finalPot, community), 500);
+      } else {
+        setTimeout(() => advanceTo(next, finalPot, community), 500);
+      }
+    }
+  };
+
+  // ── derived state ───────────────────────────────────────────────
+  const canAct    = phase !== 'idle' && phase !== 'end' && phase !== 'showdown';
+  const showComm  = community.length > 0;
+  const commSlots = Array.from({ length: 5 }, (_, i) => community[i] ?? null);
+
+  const resultColor = result?.winner === 'player' ? 'var(--ss-green)'
+    : result?.winner === 'bot' ? 'var(--ss-red)' : 'var(--ss-text-dim)';
+
+  // ── render ──────────────────────────────────────────────────────
+  return (
+    <>
+      <Navigation />
+      <div className="ss-page">
+        <div className="ss-pill ss-pill-gold" style={{ marginBottom: 10 }}>Demo grade · Math.random()</div>
+        <h1 className="ss-h1">Texas Hold'em</h1>
+        <p className="ss-sub">Heads-up vs the bot. Both ante in — best 5-of-7 at showdown wins.</p>
+
+        <div className="ss-side-grid">
+          {/* ── main game card ── */}
+          <div className="ss-card" style={{ padding: 20 }}>
+
+            {/* stats bar */}
+            <div style={{
+              display: 'flex', justifyContent: 'space-between',
+              alignItems: 'center', marginBottom: 14, flexWrap: 'wrap', gap: 10,
+            }}>
+              <div>
+                <div className="ss-stat-label">Bankroll</div>
+                <div style={{ fontSize: 22, fontWeight: 700 }}>${bankroll.toLocaleString()}</div>
+              </div>
+              <div>
+                <div className="ss-stat-label">Pot</div>
+                <div style={{ fontSize: 22, fontWeight: 700, color: 'var(--ss-gold)' }}>
+                  ${pot.toLocaleString()}
+                </div>
+              </div>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                  <span className="ss-stat-label" style={{ margin: 0 }}>Ante</span>
+                  <input type="number" value={ante}
+                    onChange={e => setAnte(Math.max(1, parseInt(e.target.value) || 0))}
+                    disabled={phase !== 'idle'}
+                    className="ss-mono"
+                    style={{ width: 72, padding: '5px 8px', borderRadius: 8, background: 'var(--ss-bg-soft)', border: '1px solid var(--ss-border)', color: 'var(--ss-text)', fontSize: 14 }} />
+                </div>
+                {canAct && (
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span className="ss-stat-label" style={{ margin: 0 }}>Raise</span>
+                    <input type="number" value={streetBet}
+                      onChange={e => setStreetBet(Math.max(1, parseInt(e.target.value) || 0))}
+                      className="ss-mono"
+                      style={{ width: 72, padding: '5px 8px', borderRadius: 8, background: 'var(--ss-bg-soft)', border: '1px solid var(--ss-border)', color: 'var(--ss-text)', fontSize: 14 }} />
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* phase badge */}
+            {phase !== 'idle' && (
+              <div style={{
+                textAlign: 'center', marginBottom: 10,
+                fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase',
+                color: 'var(--ss-gold)', fontWeight: 700,
+              }}>
+                {PHASE_LBL[phase] || phase}
+              </div>
+            )}
+
+            {/* community */}
+            {showComm ? (
+              <div style={{ marginBottom: 12 }}>
+                <div className="ss-stat-label" style={{ marginBottom: 6, textAlign: 'center' }}>Community</div>
+                <div style={{ display: 'flex', gap: 6, justifyContent: 'center', flexWrap: 'wrap' }}>
+                  {commSlots.map((card, i) =>
+                    card ? <CardFace key={i} card={card} size="sm" />
+                         : <CardSlot  key={i} size="sm" />
+                  )}
+                </div>
+              </div>
+            ) : phase !== 'idle' ? (
+              <div style={{
+                textAlign: 'center', marginBottom: 12,
+                padding: '8px 0', borderTop: '1px solid var(--ss-border-soft)',
+                borderBottom: '1px solid var(--ss-border-soft)',
+                fontSize: 11, color: 'var(--ss-text-muted)', letterSpacing: '0.12em',
+              }}>
+                FLOP &nbsp;·&nbsp; TURN &nbsp;·&nbsp; RIVER
+              </div>
+            ) : null}
+
+            {/* hole cards */}
+            <div style={{
+              display: 'flex', justifyContent: 'space-around',
+              marginBottom: 12, gap: 12,
+            }}>
+              {/* player */}
+              <div style={{ textAlign: 'center' }}>
+                <div className="ss-stat-label" style={{ marginBottom: 6 }}>You</div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  {playerHole.length
+                    ? playerHole.map((c, i) => <CardFace key={i} card={c} size="sm" />)
+                    : [<CardSlot key={0} size="sm" />, <CardSlot key={1} size="sm" />]}
+                </div>
+                {playerHandHint && (
+                  <div style={{
+                    marginTop: 5, fontSize: 11, fontWeight: 700,
+                    color: 'var(--ss-green)',
+                    background: 'rgba(74,222,128,0.08)',
+                    border: '1px solid rgba(74,222,128,0.25)',
+                    borderRadius: 6, padding: '2px 8px', display: 'inline-block',
+                  }}>
+                    {playerHandHint}
+                  </div>
+                )}
+                {result?.playerHand && !playerHandHint && (
+                  <div style={{ marginTop: 5, fontSize: 11, color: resultColor, fontWeight: 600 }}>
+                    {result.playerHand}
+                  </div>
+                )}
+              </div>
+
+              {/* bot */}
+              <div style={{ textAlign: 'center' }}>
+                <div className="ss-stat-label" style={{ marginBottom: 6 }}>Bot</div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  {botHole.length
+                    ? revealBot
+                      ? botHole.map((c, i) => <CardFace key={i} card={c} size="sm" />)
+                      : [<CardBack key={0} size="sm" />, <CardBack key={1} size="sm" />]
+                    : [<CardSlot key={0} size="sm" />, <CardSlot key={1} size="sm" />]}
+                </div>
+                {result?.botHand && (
+                  <div style={{ marginTop: 5, fontSize: 11, color: 'var(--ss-text-muted)', fontWeight: 500 }}>
+                    {result.botHand}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* bot action feedback */}
+            {botMsg && !result && (
+              <div style={{ textAlign: 'center', marginBottom: 8, fontSize: 12, color: 'var(--ss-text-muted)', fontStyle: 'italic' }}>
+                {botMsg}
+              </div>
+            )}
+
+            {/* result / prompt */}
+            <div style={{
+              textAlign: 'center', marginBottom: 14,
+              color: result ? resultColor : 'var(--ss-text-dim)',
+              fontWeight: result ? 700 : 400, fontSize: 14, minHeight: 20,
+            }}>
+              {message}
+            </div>
+
+            {/* action buttons */}
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+              {phase === 'idle' && (
+                <button className="ss-btn ss-btn-primary"
+                  onClick={deal} disabled={ante > bankroll || ante <= 0}
+                  style={{ minWidth: 140, height: 44, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+                  Deal Hand
+                </button>
+              )}
+
+              {canAct && (
+                <>
+                  <button onClick={playerFold} style={{
+                    minWidth: 80, height: 44, fontSize: 14,
+                    letterSpacing: '0.06em', textTransform: 'uppercase',
+                    borderRadius: 999, border: '1px solid rgba(239,93,93,0.4)',
+                    background: 'rgba(239,93,93,0.07)', color: 'var(--ss-red)',
+                    cursor: 'pointer', fontFamily: 'var(--ss-font)', fontWeight: 600,
+                  }}>
+                    Fold
+                  </button>
+                  <button className="ss-btn" onClick={playerCheck}
+                    style={{ minWidth: 110, height: 44, fontSize: 14, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+                    {phase === 'preflop' ? 'See Flop' : 'Check'}
+                  </button>
+                  <button className="ss-btn ss-btn-primary" onClick={playerBet}
+                    disabled={streetBet > bankroll || streetBet <= 0}
+                    style={{ minWidth: 130, height: 44, fontSize: 14, letterSpacing: '0.06em', textTransform: 'uppercase' }}>
+                    Raise ${streetBet}
+                  </button>
+                </>
+              )}
+
+              {phase === 'end' && bankroll > 0 && (
+                <button className="ss-btn ss-btn-primary"
+                  onClick={() => { setPhase('idle'); setMessage('Set your ante and deal a hand.'); }}
+                  style={{ minWidth: 140, height: 44, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase' }}>
+                  New Hand
+                </button>
+              )}
+
+              {phase === 'end' && bankroll <= 0 && (
+                <button className="ss-btn"
+                  onClick={() => { setBankroll(1000); setPhase('idle'); setMessage('Reloaded $1,000. Good luck!'); }}
+                  style={{ minWidth: 160, height: 44, fontSize: 13, textTransform: 'uppercase' }}>
+                  Reload $1,000
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* ── sidebar ── */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {/* history */}
+            <div className="ss-card">
+              <div className="ss-stat-label" style={{ marginBottom: 10 }}>Recent hands</div>
+              {history.length === 0 ? (
+                <div style={{ color: 'var(--ss-text-muted)', fontSize: 13 }}>No hands yet.</div>
+              ) : history.map((h, i) => (
+                <div key={i} style={{
+                  display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start',
+                  padding: '7px 0', borderBottom: '1px solid var(--ss-border-soft)', fontSize: 13,
+                }}>
+                  <div>
+                    <div style={{
+                      fontWeight: 600,
+                      color: h.winner === 'player' ? 'var(--ss-green)'
+                           : h.winner === 'bot'    ? 'var(--ss-red)'
+                           : 'var(--ss-text-dim)',
+                    }}>
+                      {h.winner === 'player' ? '✓ Win' : h.winner === 'bot' ? '✗ Loss' : '⇌ Tie'}
+                    </div>
+                    {h.playerHand && <div style={{ fontSize: 11, color: 'var(--ss-text-muted)', marginTop: 2 }}>{h.playerHand}</div>}
+                  </div>
+                  <span className="ss-mono" style={{
+                    color: h.delta > 0 ? 'var(--ss-green)' : h.delta < 0 ? 'var(--ss-red)' : 'var(--ss-text-muted)',
+                    fontWeight: 600,
+                  }}>
+                    {h.delta > 0 ? '+' : h.delta === 0 ? '±' : '-'}${Math.abs(h.delta)}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {/* hand rankings */}
+            <div className="ss-card">
+              <div className="ss-stat-label" style={{ marginBottom: 8 }}>Hand rankings</div>
+              {[
+                ['Royal Flush',     '10-J-Q-K-A suited'],
+                ['Straight Flush',  '5 in a row, suited'],
+                ['Four of a Kind',  '4 same rank'],
+                ['Full House',      '3+2 of a kind'],
+                ['Flush',           '5 same suit'],
+                ['Straight',        '5 in a row'],
+                ['Three of a Kind', '3 same rank'],
+                ['Two Pair',        '2 pairs'],
+                ['One Pair',        '2 same rank'],
+                ['High Card',       'No match'],
+              ].map(([name, desc]) => (
+                <div key={name} style={{
+                  display: 'flex', justifyContent: 'space-between',
+                  padding: '3px 0', fontSize: 11,
+                  borderBottom: '1px solid var(--ss-border-soft)',
+                }}>
+                  <span style={{ color: 'var(--ss-text-dim)', fontWeight: 600 }}>{name}</span>
+                  <span style={{ color: 'var(--ss-text-muted)' }}>{desc}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -15,8 +15,9 @@ import { WindowProvider } from './context/WindowContext';
 const store = configureStore();
 
 
+restoreCSRF();
+
 if (process.env.NODE_ENV !== 'production') {
-  restoreCSRF();
   window.csrfFetch = csrfFetch;
   window.store = store;
 }

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -741,7 +741,7 @@ button.bet-option,
   border-radius: var(--ss-r-lg);
   padding: 18px 20px;
 }
-.ss-stat-card { padding: 18px 20px; }
+
 .ss-stat-label {
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -767,15 +767,6 @@ button.bet-option,
 
 .ss-mono { font-family: var(--ss-mono); }
 
-.ss-grid-stats {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 14px;
-  margin-bottom: 24px;
-}
-@media (max-width: 900px) {
-  .ss-grid-stats { grid-template-columns: repeat(2, 1fr); }
-}
 
 .ss-side-grid {
   display: grid;

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://socialstakes-api.fly.dev/api/:path*"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,25 @@
         "aws-sdk": "^2.1401.0",
         "multer": "^1.4.5-lts.1",
         "socket.io-client": "^4.6.1"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.60.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -182,6 +201,21 @@
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -418,6 +452,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -631,6 +697,15 @@
     }
   },
   "dependencies": {
+    "@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.60.0"
+      }
+    },
     "@socket.io/component-emitter": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
@@ -753,6 +828,13 @@
       "requires": {
         "is-callable": "^1.1.3"
       }
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -912,6 +994,22 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.60.0"
+      }
+    },
+    "playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "aws-sdk": "^2.1401.0",
     "multer": "^1.4.5-lts.1",
     "socket.io-client": "^4.6.1"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.60.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,17 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './e2e',
+  timeout: 30000,
+  retries: 1,
+  reporter: 'line',
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:3000',
+    headless: true,
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});


### PR DESCRIPTION
## Summary
- Adds a self-contained SP Blackjack game at `/play/blackjack` (`frontend/src/components/games/Blackjack.js`) following the HoldEm SP demo pattern.
- Wires it into the lobby via `GameTile` STUB_ROUTES (`single_blackjack` → `/play/blackjack`).
- Adds Playwright e2e coverage (`e2e/blackjack.spec.js`).

## In-game coverage
- 6-deck shoe, auto-reshuffles when low.
- Deal → player + dealer two-card open with hole card hidden.
- Hit, Stand, Double (any first two), Split (same rank, capped at 4 hands), Split-Aces (one card each, auto-stand).
- Insurance prompt when dealer shows Ace; pays 2:1 on dealer BJ, otherwise lost.
- Dealer stands on all 17.
- Player blackjack pays 3:2 (immediate, no dealer play).
- Dealer BJ resolves instantly; player BJ + dealer BJ = push.
- Reload button when bankroll hits zero. Recent-hand history sidebar.

## Defensive hardening
Caught during stress-testing with rapid scripted clicks:
- `actingRef` blocks re-entry until each player action's async transition completes.
- `phaseRef` consulted instead of closure-captured `phase` inside handlers, so stale snapshots cannot pass the guard.
- `finalizeRound` treats any hand value > 21 as a loss regardless of stored `busted` flag.

## Test plan
- [x] `npm run build` in `frontend/` succeeds
- [x] Playwright e2e: 4/4 passing
- [x] Manual play (BJ +$37 on $25, win +$25, loss -$25, double -$50 verified against bankroll deltas)
- [ ] Vercel preview deploy spot-check
