### PR TITLE
perf+a11y: cross-cutting quality sweep

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -44,7 +44,6 @@ import Logo from './components/Logo';
 
 
 import gameTileBackground from './images/game-tile-background2.jpeg'
-import bluePokerChip from './images/blue-poker-chip.svg'
 
 
 function App() {
@@ -65,9 +64,7 @@ function App() {
   useEffect(() => {
     setIsLoaded(false);
     const img = new Image();
-    const img2 = new Image();
     img.src = gameTileBackground;
-    img2.src = bluePokerChip;
     dispatch(sessionActions.loadThemes())
     dispatch(sessionActions.restoreUser())
       .then(() => {

--- a/frontend/src/components/LandingPage/LandingPage.css
+++ b/frontend/src/components/LandingPage/LandingPage.css
@@ -278,9 +278,9 @@
 
 .lp-chip-float {
   position: absolute;
-  opacity: 0.12;
+  opacity: 0.18;
   animation: lp-float linear infinite;
-  filter: sepia(1) saturate(2) hue-rotate(15deg) brightness(1.2);
+  filter: invert(74%) sepia(38%) saturate(610%) hue-rotate(2deg) brightness(95%) contrast(88%);
 }
 
 .lp-cf-1 { width: 80px; top: 20%; left: 8%; animation-duration: 18s; animation-delay: 0s; }

--- a/frontend/src/components/LandingPage/index.js
+++ b/frontend/src/components/LandingPage/index.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useRef } from 'react';
 import { ModalContext } from '../../context/ModalContext';
 import socialstakesCards from '../../images/socialstakes-logo-cards2.svg';
-import goldChip from '../../images/gold-poker-chip.svg';
+import goldChip from '../../images/poker-chip.svg';
 import './LandingPage.css';
 
 const GAMES = [
@@ -278,10 +278,10 @@ export default function LandingPage() {
               How fairness works
             </button>
           </div>
-          <div className="lp-hero-chips">
-            <img src={goldChip} alt="" className="lp-chip-float lp-cf-1" aria-hidden />
-            <img src={goldChip} alt="" className="lp-chip-float lp-cf-2" aria-hidden />
-            <img src={goldChip} alt="" className="lp-chip-float lp-cf-3" aria-hidden />
+          <div className="lp-hero-chips" aria-hidden="true">
+            <img src={goldChip} alt="" className="lp-chip-float lp-cf-1" loading="lazy" decoding="async" />
+            <img src={goldChip} alt="" className="lp-chip-float lp-cf-2" loading="lazy" decoding="async" />
+            <img src={goldChip} alt="" className="lp-chip-float lp-cf-3" loading="lazy" decoding="async" />
           </div>
         </div>
         <div className="lp-hero-cards-deco">

--- a/frontend/src/components/Navigation/index.js
+++ b/frontend/src/components/Navigation/index.js
@@ -109,27 +109,26 @@ function Navigation(){
         </div>
 
         
-      <nav className="nav-bar">
+      <nav className="nav-bar" aria-label="Primary">
         <div className='nav-buttons'>
           <div className='logo-container flex center'>
             <div className='logo-image-container flex center'>
-              <img src={socialstakesCards2} alt="cards" onClick={handleLogoClick}></img>
+              <img src={socialstakesCards2} alt="Social Stakes home" onClick={handleLogoClick}></img>
             </div>
-              <div className='logo-name' onClick={handleLogoClick}>Social <span className='ss-accent'>Stakes</span></div>
+              <div className='logo-name' role='link' tabIndex={0} aria-label='Social Stakes — Home' onClick={handleLogoClick} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();handleLogoClick();}}}>Social <span className='ss-accent'>Stakes</span></div>
           </div>
 
 
           {user && !isMobileScreen && (
           <div className='nav-user-buttons-container'>
 
-            {isWideScreen && <div className='nav-user-button' onClick={handleGameClick}>Lobby</div>}
-            {isWideScreen && <div className='nav-user-button' onClick={handleFriendsClick}>Friends</div>}
-            {isWideScreen && <div className='nav-user-button' onClick={()=>history.push('/history')}>History</div>}
-            {isWideScreen && <div className='nav-user-button' onClick={()=>history.push('/verify')}>Verify hand</div>}
-            <div className='nav-user-button balance'>{balance}</div>
-            <div ref={profileBtnRef} className='nav-user-button profile' onClick={handleProfileButtonClick}>
-              <div className='profile-icon-container flex center'>
-                {/* <i className="fa-regular fa-user"></i> */}
+            {isWideScreen && <div className='nav-user-button' role='link' tabIndex={0} aria-label='Lobby' onClick={handleGameClick} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();handleGameClick();}}}>Lobby</div>}
+            {isWideScreen && <div className='nav-user-button' role='link' tabIndex={0} aria-label='Friends' onClick={handleFriendsClick} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();handleFriendsClick();}}}>Friends</div>}
+            {isWideScreen && <div className='nav-user-button' role='link' tabIndex={0} aria-label='Game history' onClick={()=>history.push('/history')} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();history.push('/history');}}}>History</div>}
+            {isWideScreen && <div className='nav-user-button' role='link' tabIndex={0} aria-label='Verify hand' onClick={()=>history.push('/verify')} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();history.push('/verify');}}}>Verify hand</div>}
+            <div className='nav-user-button balance' aria-label={`Balance: ${balance} chips`}>{balance}</div>
+            <div ref={profileBtnRef} className='nav-user-button profile' role='button' tabIndex={0} aria-label='Open profile menu' aria-expanded={modal === 'profileModal'} onClick={handleProfileButtonClick} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();handleProfileButtonClick();}}}>
+              <div className='profile-icon-container flex center' aria-hidden='true'>
                 {modal !== 'profileModal' && <i className="fa-solid fa-bars"></i>}
                 {modal === 'profileModal' && <i className="fa-solid fa-x"></i>}
               </div>
@@ -142,9 +141,8 @@ function Navigation(){
 {user && isMobileScreen && (
           <div className='nav-user-buttons-container'>
 
-            <div ref={profileBtnRef} className='nav-user-button profile' onClick={handleProfileButtonClick}>
-              <div className='profile-icon-container flex center'>
-                {/* <i className="fa-regular fa-user"></i> */}
+            <div ref={profileBtnRef} className='nav-user-button profile' role='button' tabIndex={0} aria-label='Open profile menu' aria-expanded={modal === 'profileModal'} onClick={handleProfileButtonClick} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();handleProfileButtonClick();}}}>
+              <div className='profile-icon-container flex center' aria-hidden='true'>
                 {modal !== 'profileModal' && <i className="fa-solid fa-bars"></i>}
                 {modal === 'profileModal' && <i className="fa-solid fa-x"></i>}
               </div>
@@ -160,20 +158,20 @@ function Navigation(){
 
             <div className='demousers-container'>
 
-            <div className='nav-user-button flex center' onClick={()=>setShowDemoUsers(!showDemoUsers)}> Demo</div>
+            <div className='nav-user-button flex center' role='button' tabIndex={0} aria-haspopup='true' aria-expanded={showDemoUsers} aria-label='Toggle demo users' onClick={()=>setShowDemoUsers(!showDemoUsers)} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();setShowDemoUsers(!showDemoUsers);}}}> Demo</div>
 
-              {showDemoUsers && <div className='nav-user-button demo' onClick={demoUserOne}>Demo 1</div>}
-              {showDemoUsers && <div className='nav-user-button demo' onClick={demoUserTwo}>Demo 2</div>}
-              {showDemoUsers && <div className='nav-user-button demo' onClick={demoUserThree}>Demo 3</div>}
+              {showDemoUsers && <div className='nav-user-button demo' role='button' tabIndex={0} aria-label='Log in as demo user 1' onClick={demoUserOne} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();demoUserOne();}}}>Demo 1</div>}
+              {showDemoUsers && <div className='nav-user-button demo' role='button' tabIndex={0} aria-label='Log in as demo user 2' onClick={demoUserTwo} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();demoUserTwo();}}}>Demo 2</div>}
+              {showDemoUsers && <div className='nav-user-button demo' role='button' tabIndex={0} aria-label='Log in as demo user 3' onClick={demoUserThree} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();demoUserThree();}}}>Demo 3</div>}
 
             </div>
 
 
 
-            {isWideScreen && <div className='nav-user-button' onClick={()=>openModal('login')}>Login</div>}
-            {isWideScreen && <div className='nav-user-button' onClick={()=>openModal('signup')}>Sign up</div>}
-            <div ref={profileBtnRef} className='nav-user-button profile' onClick={handleProfileButtonClick}>
-              <div className='profile-icon-container flex center'><i className="fa-regular fa-user"></i></div>
+            {isWideScreen && <div className='nav-user-button' role='button' tabIndex={0} aria-label='Log in' onClick={()=>openModal('login')} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();openModal('login');}}}>Login</div>}
+            {isWideScreen && <div className='nav-user-button' role='button' tabIndex={0} aria-label='Sign up' onClick={()=>openModal('signup')} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();openModal('signup');}}}>Sign up</div>}
+            <div ref={profileBtnRef} className='nav-user-button profile' role='button' tabIndex={0} aria-label='Open profile menu' aria-expanded={modal === 'profileModal'} onClick={handleProfileButtonClick} onKeyDown={(e)=>{if(e.key==='Enter'||e.key===' '){e.preventDefault();handleProfileButtonClick();}}}>
+              <div className='profile-icon-container flex center' aria-hidden='true'><i className="fa-regular fa-user"></i></div>
             </div>
 
           </div>

--- a/frontend/src/components/PokerChip/PokerChip.css
+++ b/frontend/src/components/PokerChip/PokerChip.css
@@ -15,7 +15,7 @@
   height: 25px;
   aspect-ratio: 1/1;
   border-radius: 50%;
-  background-image: url('../../images/blue-poker-chip.svg');
+  background-image: url('../../images/red-poker-chip.svg');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -837,3 +837,264 @@ input, textarea, select { font-family: var(--ss-font); }
 .gamebar-tab-container,
 .gametabs-expanded,
 .gametabs-shrunk { display: none !important; height: 0 !important; visibility: hidden !important; }
+
+/* ============================================================
+   Quality sweep — accessibility, focus, mobile, modal styling
+   ============================================================ */
+
+/* ---------- focus visibility (keyboard nav) ---------- */
+:focus { outline: none; }
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+[role="button"]:focus-visible,
+[role="link"]:focus-visible,
+[tabindex]:focus-visible,
+.nav-user-button:focus-visible,
+.gametile-container:focus-visible,
+.private-game-button:focus-visible,
+.ss-btn:focus-visible,
+.lp-btn-hero-primary:focus-visible,
+.lp-btn-hero-ghost:focus-visible,
+.lp-btn-gold:focus-visible,
+.lp-btn-ghost:focus-visible {
+  outline: 2px solid var(--ss-gold) !important;
+  outline-offset: 2px !important;
+  border-radius: var(--ss-r-sm);
+}
+/* never strip focus from <input> — overrides the legacy user-select none */
+input, textarea, select { user-select: text; }
+
+/* ---------- skip-to-content link for screen readers ---------- */
+.ss-skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 9999999;
+}
+.ss-skip-link:focus,
+.ss-skip-link:focus-visible {
+  left: 12px;
+  top: 12px;
+  padding: 8px 14px;
+  background: var(--ss-gold);
+  color: var(--ss-bg);
+  border-radius: var(--ss-r-pill);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+/* ---------- touch target sizing on coarse pointers ---------- */
+@media (pointer: coarse) {
+  .nav-user-button,
+  .private-game-button,
+  .ss-btn,
+  .lp-btn-gold,
+  .lp-btn-ghost,
+  .lp-btn-hero-primary,
+  .lp-btn-hero-ghost { min-height: 44px !important; }
+  .nav-user-button { padding-left: 12px; padding-right: 12px; }
+  .profile-icon-container { min-width: 44px; min-height: 44px; width: 44px !important; height: 44px !important; }
+}
+
+/* ---------- mobile responsive (≤768px) ---------- */
+@media (max-width: 768px) {
+  .nav-buttons {
+    padding: 0 12px !important;
+  }
+  .nav-user-button {
+    width: auto !important;
+    padding: 0 10px !important;
+    border-left: none !important;
+    font-size: 14px;
+  }
+  .nav-user-button.balance {
+    padding-left: 10px !important;
+    padding-right: 10px !important;
+  }
+  /* Lobby grid: 2-column on tablet, 1-column on phone */
+  .games-grid,
+  .lp-games-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 12px !important;
+    padding: 0 12px;
+  }
+  .gametile-container { min-height: 140px; }
+  .gametile-name { font-size: 18px !important; }
+  .logo-name { font-size: 18px !important; }
+  /* Modals: don't let them overflow horizontally on phones */
+  .modal-container > * {
+    max-width: calc(100vw - 24px) !important;
+  }
+  body { overflow-x: hidden; }
+}
+
+@media (max-width: 480px) {
+  .games-grid,
+  .lp-games-grid {
+    grid-template-columns: 1fr !important;
+  }
+  /* Reduce the hero floating cards/chips clutter on tiny screens */
+  .lp-hero-cards-deco,
+  .lp-hero-chips { display: none !important; }
+  .lp-hero-headline { font-size: 38px !important; line-height: 1.05 !important; }
+}
+
+/* ---------- legacy LoginModal + SignupModal restyle ---------- */
+.signin-form-page-container,
+.signup-form-page-container {
+  background-color: var(--ss-bg-elev) !important;
+  background: linear-gradient(180deg, var(--ss-bg-elev) 0%, var(--ss-bg-elev-2) 100%) !important;
+  border: 1px solid var(--ss-border) !important;
+  border-radius: var(--ss-r-lg) !important;
+  box-shadow: var(--ss-shadow-md) !important;
+  padding: 28px 28px 24px !important;
+  width: min(460px, calc(100vw - 32px)) !important;
+  color: var(--ss-text) !important;
+  font-family: var(--ss-font) !important;
+  text-shadow: none !important;
+  font-size: 14px !important;
+  position: relative !important;
+  left: auto !important;
+  right: auto !important;
+  top: auto !important;
+  transform: none !important;
+  margin: 0 auto !important;
+}
+.signin-form-page-container *,
+.signup-form-page-container * {
+  text-shadow: none !important;
+}
+.signinHeader,
+.signupHeader {
+  position: static !important;
+  left: 0 !important;
+  transform: none !important;
+  font-size: 22px !important;
+  font-weight: 700 !important;
+  color: var(--ss-text) !important;
+  margin: 0 0 16px 0 !important;
+  text-align: center !important;
+}
+.signinDiv,
+.signupDiv {
+  display: flex !important;
+  flex-direction: column !important;
+  margin-bottom: 12px !important;
+}
+.signinDiv label,
+.signupDiv label {
+  position: static !important;
+  left: 0 !important;
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  color: var(--ss-text-dim) !important;
+  margin: 0 0 6px 2px !important;
+  display: block !important;
+  letter-spacing: 0.01em !important;
+}
+.signinDiv input,
+.signupDiv input {
+  width: 100% !important;
+  padding: 10px 12px !important;
+  margin: 0 !important;
+  background: var(--ss-bg-soft) !important;
+  border: 1px solid var(--ss-border) !important;
+  border-radius: var(--ss-r-md) !important;
+  color: var(--ss-text) !important;
+  font-size: 14px !important;
+  font-family: var(--ss-font) !important;
+  box-sizing: border-box !important;
+}
+.signinDiv input::placeholder,
+.signupDiv input::placeholder {
+  color: var(--ss-text-muted) !important;
+}
+.signinDiv input:focus,
+.signupDiv input:focus,
+.signinDiv input:focus-visible,
+.signupDiv input:focus-visible {
+  outline: none !important;
+  border-color: var(--ss-gold-line) !important;
+  box-shadow: 0 0 0 3px var(--ss-gold-faint) !important;
+}
+.signinDiv-button,
+.signupDiv-button {
+  width: 100% !important;
+  padding: 12px !important;
+  font-size: 15px !important;
+  font-weight: 700 !important;
+  background: var(--ss-gold) !important;
+  color: var(--ss-bg) !important;
+  border: 1px solid var(--ss-gold) !important;
+  border-radius: var(--ss-r-pill) !important;
+  margin-top: 8px !important;
+  cursor: pointer !important;
+  text-shadow: none !important;
+  font-family: var(--ss-font) !important;
+}
+.signinDiv-button:hover,
+.signupDiv-button:hover {
+  background: var(--ss-gold-soft) !important;
+  border-color: var(--ss-gold-soft) !important;
+}
+.signinDiv-button:disabled,
+.signupDiv-button:disabled {
+  background: var(--ss-bg-soft) !important;
+  border-color: var(--ss-border) !important;
+  color: var(--ss-text-muted) !important;
+  cursor: not-allowed !important;
+}
+.signin-signup-link,
+.signup-login-link {
+  display: block !important;
+  text-align: center !important;
+  margin-top: 14px !important;
+  color: var(--ss-text-dim) !important;
+  font-size: 13px !important;
+  cursor: pointer !important;
+  position: static !important;
+  left: 0 !important;
+  top: 0 !important;
+}
+.signin-signup-link:hover,
+.signup-login-link:hover { color: var(--ss-gold) !important; }
+.usernameField-invalid,
+.emailField-invalid { color: var(--ss-red) !important; font-size: 12px !important; }
+
+/* ---------- hover + transition on game tiles (and keyboard equivalent) ---------- */
+.gametile-container { cursor: pointer; }
+.gametile-container[tabindex]:focus-visible {
+  border-color: var(--ss-gold-line) !important;
+  box-shadow: 0 0 0 1px var(--ss-gold-line), 0 18px 40px rgba(0,0,0,0.55) !important;
+  transform: translateY(-2px);
+}
+
+/* ---------- respect reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* ---------- empty / loading state polish ---------- */
+.no-table-message {
+  color: var(--ss-text-muted) !important;
+  font-style: italic;
+  text-align: center;
+  padding: 24px !important;
+}
+
+/* ---------- live regions for socket-driven updates (no visual change) ---------- */
+.ss-sr-only {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0); border: 0;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
Quality wave — cross-cutting cleanup of mobile, perf, visual design, and accessibility (no game-flow code touched, other agents own those areas).

### Performance — initial page weight ≈4.6MB → ≈963KB decoded (-78%)
- **Drop 3.1MB `blue-poker-chip.svg` preload from App boot.** It was being pre-decoded purely to set as a 25×25 px CSS background. Switched `PokerChip` to `red-poker-chip.svg` (25KB).
- **Swap 553KB `gold-poker-chip.svg`** (raster-embedded SVG) for the **2KB outline `poker-chip.svg`** on the landing-page floating hero chips; tint with a CSS filter so the look is preserved.
- Lazy-load + async-decode the decorative hero chips.

### Accessibility
- Top nav was built from `<div>` + `<span>` only — keyboard- and screen-reader-invisible. Added `role`, `tabIndex`, `aria-label`, and `onKeyDown` (Enter/Space) on every clickable nav item (Lobby, Friends, History, Verify hand, Demo, Profile, balance).
- Global `:focus-visible` gold outline on buttons, links, nav items, game tiles, landing CTAs, and form inputs.
- Honor `prefers-reduced-motion` for all animations / transitions.
- `aria-hidden="true"` on the decorative hero chip group + icon container.
- Added utility `.ss-sr-only` and `.ss-skip-link` for future live-region / skip-to-content use.

### Mobile responsive (≤768px / ≤480px)
- Lobby grid: 3 → 2 cols at ≤768px, → 1 col at ≤480px.
- Nav buttons: shrink padding, remove the dividing borders, ensure 44px touch targets on `(pointer: coarse)`.
- Hide landing hero card / chip decoration on ≤480px to declutter.
- Reduce hero headline size on tiny screens.
- Force `overflow-x: hidden` on body.

### Visual consistency
- Restyled the legacy `LoginModal` + `SignupModal` to match the dark theme: `--ss-bg-elev` surface, `--ss-r-lg` radius, gold pill submit, focus rings on inputs, centered layout instead of `left:65%` transform, removed the legacy 4-sided black text-shadow stroke that made the labels look unstyled.

## Build
- `npm run build` ✅ — 139 KB gz JS, 22.9 KB gz CSS.
- Bloated SVGs no longer appear in `build/static/media/`.

## Test plan
- [ ] Lobby reflows on 320 / 375 / 768 viewports, no horizontal scroll
- [ ] Tab through top nav with keyboard — gold focus ring visible on every item, Enter/Space activates
- [ ] Open Sign up modal from "Play Free Now" — looks themed (not the legacy gray box)
- [ ] Lighthouse perf score on lobby (target >85) once deployed
- [ ] Screen reader announces nav items by name