### PR TITLE
feat: real provably-fair RNG + cross-game hand history

### DIFF
--- a/e2e/history-verify.spec.js
+++ b/e2e/history-verify.spec.js
@@ -1,0 +1,79 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.BASE_URL || 'http://localhost:3001';
+
+test.describe('Provably-fair history + verify', () => {
+  test('coin flip records a hand that verifies green', async ({ page }) => {
+    await page.goto(`${BASE}/play/coinflip`);
+    await expect(page.getByText('Coin Flip')).toBeVisible({ timeout: 10000 });
+
+    // The provably-fair commitment must be visible BEFORE we bet
+    const commitment = page.getByTestId('pf-commitment');
+    await expect(commitment).toBeVisible({ timeout: 5000 });
+    const commitmentHex = await commitment.textContent();
+    expect(commitmentHex).toMatch(/^[0-9a-f]{64}$/);
+
+    // Place a flip
+    await page.getByRole('button', { name: /heads/i }).click();
+    // Animation + record
+    await page.waitForTimeout(1500);
+
+    // A "verify ✓" link should appear
+    const verifyLink = page.getByRole('link', { name: /verify/i }).first();
+    await expect(verifyLink).toBeVisible({ timeout: 5000 });
+
+    // Click into verify
+    await verifyLink.click();
+    await expect(page.getByRole('heading', { name: /Verify Hand/ })).toBeVisible({ timeout: 5000 });
+
+    // The verify pill should resolve to "✓ Outcome reproduces from seeds"
+    const verifyPill = page.getByTestId('verify-result-pill');
+    await expect(verifyPill).toHaveText(/Outcome reproduces from seeds/, { timeout: 5000 });
+
+    // The recorded commitment on verify page must match the one shown in the game
+    const recorded = await page.getByTestId('verify-commitment').textContent();
+    expect(recorded).toBe(commitmentHex);
+
+    // The live-recomputed hash should match too
+    const recomputed = await page.getByTestId('verify-recomputed-hash').textContent();
+    expect(recomputed.trim()).toBe(commitmentHex);
+  });
+
+  test('hi-lo round records and verifies', async ({ page }) => {
+    await page.goto(`${BASE}/play/hilo`);
+    await expect(page.getByRole('heading', { name: /Hi-Lo/ })).toBeVisible({ timeout: 10000 });
+
+    // Wait for PF panel to render (session async-initializes)
+    await expect(page.getByTestId('pf-commitment')).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole('button', { name: /Higher/i }).click();
+    await page.waitForTimeout(1500);
+
+    const verifyLink = page.getByRole('link', { name: /verify/i }).first();
+    await expect(verifyLink).toBeVisible({ timeout: 5000 });
+    await verifyLink.click();
+
+    await expect(page.getByTestId('verify-result-pill'))
+      .toHaveText(/Outcome reproduces from seeds/, { timeout: 5000 });
+  });
+
+  test('history page lists recorded hands and filters by game', async ({ page }) => {
+    // Pre-seed: play a coin flip
+    await page.goto(`${BASE}/play/coinflip`);
+    await expect(page.getByTestId('pf-commitment')).toBeVisible({ timeout: 5000 });
+    await page.getByRole('button', { name: /tails/i }).click();
+    await page.waitForTimeout(1500);
+
+    // Navigate to history
+    await page.goto(`${BASE}/history`);
+    await expect(page.getByRole('heading', { name: /hand history/i })).toBeVisible({ timeout: 5000 });
+
+    // Should have at least one row now
+    const rows = page.getByTestId('history-row');
+    await expect(rows.first()).toBeVisible({ timeout: 5000 });
+
+    // CSV button should be enabled
+    await expect(page.getByTestId('history-export-csv')).toBeEnabled();
+  });
+});

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -230,6 +230,10 @@ function App() {
             {isLoaded && <HistoryPage />}
           </Route>
 
+          <Route path="/verify/:id" exact>
+            {isLoaded && <VerifyHandPage />}
+          </Route>
+
           <Route path="/verify" exact>
             {isLoaded && <VerifyHandPage />}
           </Route>

--- a/frontend/src/components/HistoryPage/index.js
+++ b/frontend/src/components/HistoryPage/index.js
@@ -1,203 +1,274 @@
-import React, { useState, useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import React, { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import Navigation from '../Navigation';
+import {
+  loadHands, filterHands, aggregateHands, downloadCsv,
+  clearHistory, GAME_LABELS,
+} from '../../utils/historyStore';
 
-/**
- * "Your last 30 days" history dashboard. Mirrors 04-history.jpg in the
- * portfolio reference. For now this uses synthesized data — the underlying
- * Hands / Rounds tables are populated in the database, but the API for
- * surfacing them client-side isn't wired up. Real wiring is tracked as a
- * follow-up.
- */
+const RANGES = {
+  '7d':  7 * 24 * 3600 * 1000,
+  '30d': 30 * 24 * 3600 * 1000,
+  '90d': 90 * 24 * 3600 * 1000,
+  'All': Infinity,
+};
+
 function HistoryPage() {
-  const user = useSelector((state) => state.users.user);
-  const [range, setRange] = useState('30d');
+  const [, forceTick] = useState(0);
+  const [range, setRange]   = useState('All');
+  const [game, setGame]     = useState('all');
+  const [outcome, setOutcome] = useState('all');
 
-  const data = useMemo(() => generateMockHistory(), []);
-  const stats = useMemo(() => deriveStats(data), [data]);
+  const all = useMemo(loadHands, []);
+  const now = Date.now();
+  const fromTs = RANGES[range] === Infinity ? 0 : now - RANGES[range];
+  const filtered = useMemo(
+    () => filterHands(all, { game, outcome, fromTs }),
+    [all, game, outcome, fromTs]
+  );
+  const stats = useMemo(() => aggregateHands(filtered), [filtered]);
+
+  const curve = useMemo(() => buildCurve(filtered), [filtered]);
+
+  const onClear = () => {
+    if (window.confirm('Clear all local hand history?')) {
+      clearHistory();
+      forceTick((t) => t + 1);
+    }
+  };
 
   return (
     <>
       <Navigation />
       <div className="ss-page">
-        <h1 className="ss-h1">Your last 30 days</h1>
-        <p className="ss-sub">All hands cryptographically logged. Click any row to replay or verify.</p>
+        <h1 className="ss-h1">Your hand history</h1>
+        <p className="ss-sub">Every flip, draw, and showdown is cryptographically logged. Click any row to verify.</p>
 
+        {/* Stats grid */}
+        <div className="ss-stat-row" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 12, marginBottom: 22 }}>
+          <Stat label="Hands played" value={stats.handsPlayed} />
+          <Stat label="Total wagered" value={`$${stats.wagered.toLocaleString()}`} />
+          <Stat label="Net P/L" value={`${stats.netPL >= 0 ? '+' : '−'}$${Math.abs(stats.netPL).toLocaleString()}`} color={stats.netPL >= 0 ? 'var(--ss-green)' : 'var(--ss-red)'} />
+          <Stat label="Win rate" value={`${stats.winRate.toFixed(1)}%`} />
+          <Stat label="Biggest win" value={`+$${stats.biggestWin.toLocaleString()}`} color="var(--ss-green)" />
+          <Stat label="Biggest loss" value={`-$${Math.abs(stats.biggestLoss).toLocaleString()}`} color="var(--ss-red)" />
+        </div>
+
+        {/* Chart + Export */}
         <div className="ss-side-grid">
           <div className="ss-card" style={{ padding: 20 }}>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-              <div style={{ fontWeight: 600 }}>Bankroll curve</div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+              <div style={{ fontWeight: 600 }}>Cumulative P/L</div>
               <div style={{ display: 'flex', gap: 4 }}>
-                {['7d', '30d', '90d', 'All'].map(r => (
-                  <button key={r} onClick={() => setRange(r)}
+                {Object.keys(RANGES).map((r) => (
+                  <button key={r} onClick={() => setRange(r)} className="ss-btn"
                     style={{
-                      padding: '4px 10px', borderRadius: 999, fontSize: 12,
+                      height: 26, padding: '0 12px', fontSize: 11,
                       background: range === r ? 'var(--ss-gold-faint)' : 'transparent',
                       border: '1px solid ' + (range === r ? 'var(--ss-gold-line)' : 'var(--ss-border)'),
                       color: range === r ? 'var(--ss-gold)' : 'var(--ss-text-dim)',
-                      cursor: 'pointer', fontFamily: 'inherit',
                     }}>
                     {r}
                   </button>
                 ))}
               </div>
             </div>
-            <BankrollChart points={data.curve} />
+            <BankrollChart points={curve} />
           </div>
 
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-            <div className="ss-card">
-              <div className="ss-stat-label" style={{ marginBottom: 14 }}>Friends leaderboard · May</div>
-              {data.leaderboard.map((row, i) => (
-                <div key={i} style={{
-                  display: 'flex', alignItems: 'center', gap: 10,
-                  padding: '8px 0', borderBottom: i < data.leaderboard.length - 1 ? '1px solid var(--ss-border-soft)' : 'none',
-                  fontSize: 13,
-                }}>
-                  <span className={`ss-avatar ${row.color}`} style={{ width: 22, height: 22, fontSize: 11 }}>{i + 1}</span>
-                  <span style={{ flex: 1 }}>{row.name}</span>
-                  <span className="ss-mono" style={{ color: row.delta >= 0 ? 'var(--ss-green)' : 'var(--ss-red)', fontWeight: 600 }}>
-                    {row.delta >= 0 ? '+' : '−'} $ {Math.abs(row.delta).toLocaleString()}
-                  </span>
-                </div>
-              ))}
+          <div className="ss-card" style={{ padding: 18 }}>
+            <div className="ss-stat-label" style={{ marginBottom: 8 }}>Export</div>
+            <div style={{ fontSize: 13, color: 'var(--ss-text-dim)', lineHeight: 1.5, marginBottom: 14 }}>
+              Download a CSV of every filtered hand, including commitment hash, seeds and nonce.
+              Anyone can re-derive the outcomes independently.
             </div>
-
-            <div className="ss-card">
-              <div className="ss-stat-label" style={{ marginBottom: 8 }}>Export</div>
-              <div style={{ fontSize: 13, color: 'var(--ss-text-dim)', lineHeight: 1.5, marginBottom: 14 }}>
-                Download a signed CSV of every hand. Verifiable against the public seed log.
-              </div>
-              <button className="ss-btn ss-btn-primary" style={{ width: '100%', height: 40 }} disabled>
-                Download CSV (signed)
-              </button>
-            </div>
+            <button
+              className="ss-btn ss-btn-primary"
+              style={{ width: '100%', height: 38 }}
+              disabled={!filtered.length}
+              onClick={() => downloadCsv(filtered)}
+              data-testid="history-export-csv"
+            >
+              Download CSV
+            </button>
+            <button
+              className="ss-btn"
+              style={{ width: '100%', height: 32, marginTop: 8, fontSize: 12 }}
+              onClick={onClear}
+              disabled={!all.length}
+            >
+              Clear local history
+            </button>
           </div>
         </div>
 
-        <div className="ss-card" style={{ marginTop: 22, padding: '8px 0', overflow: 'hidden' }}>
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
-            <thead>
-              <tr>
-                {['Hand', 'Time', 'Table', 'Cards', 'Result', 'Δ', ''].map(h => (
-                  <th key={h} style={{
-                    textAlign: 'left', padding: '12px 20px',
-                    color: 'var(--ss-text-muted)', fontWeight: 500,
-                    textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: 11,
-                    borderBottom: '1px solid var(--ss-border)',
-                  }}>{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {data.hands.map((h) => (
-                <tr key={h.id}>
-                  <td style={td}><span className="ss-mono">#{h.id}</span></td>
-                  <td style={{ ...td, color: 'var(--ss-text-dim)' }}>{h.time}</td>
-                  <td style={td}>{h.table}</td>
-                  <td style={{ ...td, fontFamily: 'var(--ss-mono)' }}>{h.cards}</td>
-                  <td style={td}>
-                    <span className={`ss-pill ${resultPill(h.result)}`}>{h.result}</span>
-                  </td>
-                  <td style={{ ...td, color: h.delta >= 0 ? 'var(--ss-green)' : 'var(--ss-red)', fontWeight: 600 }} className="ss-mono">
-                    {h.delta >= 0 ? '+' : '−'} {Math.abs(h.delta)}
-                  </td>
-                  <td style={td}>
-                    <span className="ss-pill" style={{ color: 'var(--ss-text-muted)', fontSize: 11 }}>verify ✓</span>
-                  </td>
+        {/* Filters */}
+        <div className="ss-card" style={{ marginTop: 22, padding: '12px 16px', display: 'flex', gap: 14, flexWrap: 'wrap', alignItems: 'center' }}>
+          <Filter label="Game" value={game} setValue={setGame} options={[
+            ['all', 'All games'],
+            ['coinflip', 'Coin Flip'],
+            ['hilo', 'Hi-Lo'],
+            ['acey', 'Acey-Duecey'],
+            ['holdem', "Hold'em"],
+          ]} />
+          <Filter label="Outcome" value={outcome} setValue={setOutcome} options={[
+            ['all', 'All'],
+            ['wins', 'Wins'],
+            ['losses', 'Losses'],
+            ['pushes', 'Pushes'],
+          ]} />
+          <div style={{ marginLeft: 'auto', fontSize: 12, color: 'var(--ss-text-muted)' }}>
+            {filtered.length} of {all.length} hands
+          </div>
+        </div>
+
+        {/* Table */}
+        <div className="ss-card" style={{ marginTop: 14, padding: '8px 0', overflow: 'auto' }}>
+          {filtered.length === 0 ? (
+            <div style={{ padding: 28, textAlign: 'center', color: 'var(--ss-text-muted)' }}>
+              No hands recorded yet. Play <Link to="/play/coinflip" style={{ color: 'var(--ss-gold)' }}>Coin Flip</Link>,
+              {' '}<Link to="/play/hilo" style={{ color: 'var(--ss-gold)' }}>Hi-Lo</Link>,
+              {' '}<Link to="/play/acey" style={{ color: 'var(--ss-gold)' }}>Acey-Duecey</Link>,
+              {' '}or <Link to="/play/holdem" style={{ color: 'var(--ss-gold)' }}>Hold'em</Link> — every hand lands here automatically.
+            </div>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+              <thead>
+                <tr>
+                  {['Hand', 'Time', 'Game', 'Result', 'Bet', 'Δ', 'Summary', ''].map(h => (
+                    <th key={h} style={th}>{h}</th>
+                  ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {filtered.map((h) => (
+                  <tr key={h.id} data-testid="history-row">
+                    <td style={td}><span className="ss-mono">#{h.id}</span></td>
+                    <td style={{ ...td, color: 'var(--ss-text-dim)' }}>
+                      {new Date(h.ts).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                    </td>
+                    <td style={td}>{GAME_LABELS[h.game] || h.game}</td>
+                    <td style={td}>
+                      <span className={`ss-pill ${resultPill(h.delta)}`}>{h.result}</span>
+                    </td>
+                    <td style={{ ...td, fontFamily: 'var(--ss-mono)', color: 'var(--ss-text-dim)' }}>
+                      ${h.stake}
+                    </td>
+                    <td style={{ ...td, color: h.delta > 0 ? 'var(--ss-green)' : h.delta < 0 ? 'var(--ss-red)' : 'var(--ss-text-dim)', fontWeight: 600 }} className="ss-mono">
+                      {h.delta > 0 ? '+' : h.delta < 0 ? '−' : '±'}${Math.abs(h.delta)}
+                    </td>
+                    <td style={{ ...td, color: 'var(--ss-text-dim)', maxWidth: 280, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {h.summary}
+                    </td>
+                    <td style={td}>
+                      <Link to={`/verify/${h.id}`} className="ss-pill" style={{ color: 'var(--ss-gold)', fontSize: 11 }}>
+                        verify ✓
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </div>
       </div>
     </>
   );
 }
 
+function Stat({ label, value, color }) {
+  return (
+    <div className="ss-card" style={{ padding: 14 }}>
+      <div className="ss-stat-label">{label}</div>
+      <div style={{ fontSize: 22, fontWeight: 700, color: color || 'var(--ss-text)' }}>{value}</div>
+    </div>
+  );
+}
+
+function Filter({ label, value, setValue, options }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <span className="ss-stat-label" style={{ margin: 0 }}>{label}</span>
+      <select
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        style={{
+          padding: '6px 10px', borderRadius: 8,
+          background: 'var(--ss-bg-soft)', border: '1px solid var(--ss-border)',
+          color: 'var(--ss-text)', fontSize: 13, fontFamily: 'inherit',
+        }}
+      >
+        {options.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
+      </select>
+    </div>
+  );
+}
+
+const th = {
+  textAlign: 'left', padding: '12px 18px',
+  color: 'var(--ss-text-muted)', fontWeight: 500,
+  textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: 11,
+  borderBottom: '1px solid var(--ss-border)',
+};
 const td = {
-  padding: '12px 20px',
+  padding: '12px 18px',
   borderBottom: '1px solid var(--ss-border-soft)',
 };
 
-function resultPill(result) {
-  if (result === 'Blackjack' || result === 'Win' || result.startsWith('Win')) return 'ss-pill-green';
-  if (result === 'Bust' || result === 'Lose') return 'ss-pill-red';
+function resultPill(delta) {
+  if (delta > 0) return 'ss-pill-green';
+  if (delta < 0) return 'ss-pill-red';
   return '';
 }
 
+function buildCurve(hands) {
+  if (!hands.length) return [0, 0];
+  const sorted = [...hands].sort((a, b) => a.ts - b.ts);
+  let running = 0;
+  const out = [0];
+  for (const h of sorted) {
+    running += h.delta || 0;
+    out.push(running);
+  }
+  return out;
+}
+
 function BankrollChart({ points }) {
-  const W = 720, H = 260, padding = 18;
+  const W = 720, H = 220, padding = 18;
+  if (!points || points.length < 2) {
+    return (
+      <div style={{ height: H, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--ss-text-muted)', fontSize: 13 }}>
+        Play a hand to see the bankroll curve.
+      </div>
+    );
+  }
   const min = Math.min(...points);
   const max = Math.max(...points);
-  const range = max - min || 1;
+  const range = (max - min) || 1;
   const stepX = (W - padding * 2) / (points.length - 1);
   const toY = (v) => padding + (H - padding * 2) * (1 - (v - min) / range);
   const pathD = points.map((v, i) => `${i === 0 ? 'M' : 'L'} ${padding + i * stepX} ${toY(v)}`).join(' ');
   const areaD = pathD + ` L ${padding + (points.length - 1) * stepX} ${H - padding} L ${padding} ${H - padding} Z`;
+  const endColor = points[points.length - 1] >= 0 ? 'var(--ss-green)' : 'var(--ss-red)';
 
   return (
     <svg viewBox={`0 0 ${W} ${H}`} width="100%" style={{ display: 'block' }}>
       <defs>
-        <linearGradient id="ssgrad" x1="0" y1="0" x2="0" y2="1">
+        <linearGradient id="ss-history-grad" x1="0" y1="0" x2="0" y2="1">
           <stop offset="0%" stopColor="var(--ss-gold)" stopOpacity="0.35" />
           <stop offset="100%" stopColor="var(--ss-gold)" stopOpacity="0" />
         </linearGradient>
       </defs>
-      {/* gridlines */}
       {[0, 0.33, 0.66, 1].map((t, i) => (
-        <line key={i} x1={padding} x2={W - padding} y1={padding + (H - padding * 2) * t} y2={padding + (H - padding * 2) * t}
+        <line key={i} x1={padding} x2={W - padding}
+          y1={padding + (H - padding * 2) * t} y2={padding + (H - padding * 2) * t}
           stroke="var(--ss-border-soft)" strokeWidth="1" />
       ))}
-      <path d={areaD} fill="url(#ssgrad)" />
+      <path d={areaD} fill="url(#ss-history-grad)" />
       <path d={pathD} fill="none" stroke="var(--ss-gold)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-      <circle cx={padding + (points.length - 1) * stepX} cy={toY(points[points.length - 1])} r="4" fill="var(--ss-gold)" />
+      <circle cx={padding + (points.length - 1) * stepX} cy={toY(points[points.length - 1])} r="4" fill={endColor} />
     </svg>
   );
-}
-
-function generateMockHistory() {
-  let v = 3000;
-  const curve = [];
-  for (let i = 0; i < 30; i++) {
-    v += Math.round((Math.sin(i / 3) * 80) + (Math.random() - 0.4) * 140);
-    curve.push(v);
-  }
-  const hands = [];
-  const tables = ['High Tide', 'Whale Watch', 'Beginners\' Beach', 'Sara\'s table'];
-  const results = ['Win', 'Bust', 'Blackjack', 'Push', 'Win × 2', 'Lose'];
-  for (let i = 0; i < 14; i++) {
-    const r = results[Math.floor(Math.random() * results.length)];
-    const delta = r === 'Blackjack' ? 300 : r === 'Win' ? 100 : r === 'Win × 2' ? 400 : r === 'Push' ? 0 : r === 'Bust' ? -200 : -100;
-    hands.push({
-      id: 142 - i,
-      time: `${14 - Math.floor(i / 4)}:${String((33 - i * 2) % 60).padStart(2, '0')}`,
-      table: tables[i % tables.length],
-      cards: ['Q♦ 5♣ → 8♣', 'A♥ K♣', 'J♠ J♦ split → 21, 18', '9♣ 9♣ → 18', 'K♥ 7♣ → 17', '4♣ 7♣ → 11 dbl → 21'][i % 6],
-      result: r,
-      delta,
-    });
-  }
-  const leaderboard = [
-    { name: 'Marcus', delta: 4210, color: 'purple' },
-    { name: 'You', delta: 1820, color: 'yellow' },
-    { name: 'Sara', delta: 820, color: 'blue' },
-    { name: 'Leo', delta: 312, color: 'green' },
-    { name: 'Avery', delta: -94, color: 'pink' },
-    { name: 'June', delta: -640, color: 'red' },
-  ];
-  return { curve, hands, leaderboard };
-}
-
-function deriveStats(data) {
-  return {
-    handsPlayed: 1428,
-    handsDelta: 312,
-    netPL: 1820,
-    winRate: 46.4,
-    bestSession: { amount: 640, table: 'High Tide · May 4' },
-    worstSession: { amount: 180, table: 'Whale Watch · May 9' },
-  };
 }
 
 export default HistoryPage;

--- a/frontend/src/components/ProvablyFairPanel.js
+++ b/frontend/src/components/ProvablyFairPanel.js
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { getOrCreateSession, rotateSession } from '../utils/provablyFair';
+
+// A compact "Provably Fair" status card the demo games show next to the
+// bet controls. Surfaces the SHA-256 commitment of the active server
+// seed *before* outcomes are revealed, plus a "rotate" action that
+// reveals the current seed and starts a fresh one.
+
+export default function ProvablyFairPanel({ session, onRotate, revealed }) {
+  const [showRevealed, setShowRevealed] = useState(false);
+
+  if (!session) {
+    return (
+      <div className="ss-card" style={{ padding: 16, fontSize: 12, color: 'var(--ss-text-muted)' }}>
+        Initializing provably-fair seed…
+      </div>
+    );
+  }
+
+  return (
+    <div className="ss-card" style={{ padding: 16 }} data-testid="pf-panel">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+        <span className="ss-stat-label" style={{ margin: 0 }}>Provably fair · this session</span>
+        <span className="ss-pill ss-pill-green" style={{ fontSize: 10 }}>SHA-256 committed</span>
+      </div>
+
+      <Row label="Commitment" mono>
+        <span
+          className="ss-mono"
+          style={{ color: 'var(--ss-gold)', fontSize: 11, wordBreak: 'break-all' }}
+          data-testid="pf-commitment"
+        >
+          {session.commitment}
+        </span>
+      </Row>
+      <Row label="Client seed" mono>
+        <span className="ss-mono" style={{ fontSize: 11, color: 'var(--ss-text-dim)' }}>
+          {session.clientSeed}
+        </span>
+      </Row>
+      <Row label="Nonce" mono>
+        <span className="ss-mono" style={{ fontSize: 12 }}>{session.nonce}</span>
+      </Row>
+
+      {revealed && (
+        <div style={{ marginTop: 10, padding: 10, background: 'var(--ss-bg)', borderRadius: 8, border: '1px solid var(--ss-border-soft)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ fontSize: 11, color: 'var(--ss-text-muted)' }}>Last revealed seed (rotate above)</span>
+            <button
+              type="button"
+              onClick={() => setShowRevealed((v) => !v)}
+              className="ss-btn"
+              style={{ height: 22, fontSize: 11, padding: '0 8px' }}
+            >
+              {showRevealed ? 'Hide' : 'Show'}
+            </button>
+          </div>
+          {showRevealed && (
+            <div className="ss-mono" style={{ fontSize: 10, color: 'var(--ss-text-dim)', wordBreak: 'break-all', marginTop: 6 }}>
+              {revealed.serverSeed}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+        <button
+          type="button"
+          className="ss-btn"
+          style={{ flex: 1, height: 30, fontSize: 12 }}
+          onClick={onRotate}
+          data-testid="pf-rotate"
+        >
+          Reveal & rotate seed
+        </button>
+      </div>
+
+      <div style={{ marginTop: 8, fontSize: 10, color: 'var(--ss-text-muted)', lineHeight: 1.5 }}>
+        Outcomes are SHA-256(serverSeed : clientSeed : nonce). The hash above
+        was published before any bets — proof we can't change the seed mid-session.
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, children }) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '110px 1fr', gap: 10, alignItems: 'flex-start', fontSize: 12, marginBottom: 6 }}>
+      <div style={{ color: 'var(--ss-text-muted)' }}>{label}</div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+// Convenience hook: wires up session lifecycle + reveals into local state.
+export function useProvablyFairSession() {
+  const [session, setSession] = useState(null);
+  const [revealed, setRevealed] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getOrCreateSession().then((s) => {
+      if (!cancelled) setSession(s);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Caller calls this after each outcome so the panel reflects the
+  // advanced nonce.
+  const refresh = (next) => setSession(next);
+
+  const rotate = async () => {
+    setRevealed(session ? { serverSeed: session.serverSeed, commitment: session.commitment } : null);
+    const next = await rotateSession();
+    setSession(next);
+  };
+
+  return { session, revealed, refresh, rotate, setSession };
+}

--- a/frontend/src/components/VerifyHandPage/index.js
+++ b/frontend/src/components/VerifyHandPage/index.js
@@ -1,108 +1,343 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
 import Navigation from '../Navigation';
+import { getHand, loadHands, GAME_LABELS } from '../../utils/historyStore';
+import {
+  sha256Hex, verifyCommitment,
+  deriveCoinFlip, deriveCard, deriveCards, deriveDeck,
+} from '../../utils/provablyFair';
 
-const SUITS_RED = ['♥', '♦'];
-const SAMPLE_DECK = [
-  'K♥', '7♣', 'A♠', '8♣', 'Q♣', '5♣', '9♣', '9♥', 'J♥', '3♠', 'A♣', 'K♦',
-  '4♣', '2♥', '6♠', '10♦', '8♠', '5♥', 'J♣', 'Q♣', 'A♥', 'A♦', '7♥', '3♠', '8♥',
-  'K♠', '2♣', '2♦', '5♠', '6♥', 'Q♥', 'J♦', 'J♠', '4♥', '4♥', '9♣', '8♣', '10♥',
-  '10♥', '9♦', '3♥', '3♠', '6♥', '7♣', '5♦', 'K♣', '4♦', 'Q♠', '7♦', '8♦',
-];
+const SUITS = ['♠', '♥', '♦', '♣'];
+const RANK_LABELS = { 1: 'A', 11: 'J', 12: 'Q', 13: 'K' };
+const rankLabel = (r) => RANK_LABELS[r] || String(r);
+const cardFromObj = (c) => `${rankLabel(c.rank)}${SUITS[c.suit]}`;
 
-/**
- * Static demo of the provably-fair verify-a-hand surface from
- * 03-verify.jpg. Real interactive re-derivation isn't wired up yet — the
- * backend has all the data (server seeds chained via SHA-256, Bitcoin
- * block hashes from blockchain.info, client nonces in the Hands table),
- * but there is no public endpoint exposing it. This page demonstrates the
- * concept.
- */
+// Map "Ts" style strings (HoldEm format) to display.
+const HOLDEM_RANK_DISP = { T: '10' };
+const HOLDEM_SUIT_DISP = { h: '♥', d: '♦', c: '♣', s: '♠' };
+function holdemCardLabel(c) {
+  if (!c || c.length < 2) return c || '';
+  const r = HOLDEM_RANK_DISP[c[0]] || c[0];
+  return r + (HOLDEM_SUIT_DISP[c[1]] || c[1]);
+}
+
+// Re-derive the outcome for a given hand from its stored seeds. Returns
+// { matches: bool, derived: object, expected: object, reason?: string }.
+async function rederiveHand(hand) {
+  if (!hand?.pf?.serverSeed) {
+    return { matches: false, reason: 'serverSeed not yet revealed for this session' };
+  }
+  const { serverSeed, clientSeed, nonce } = hand.pf;
+
+  if (hand.game === 'coinflip') {
+    const derived = await deriveCoinFlip(serverSeed, clientSeed, nonce);
+    return {
+      matches: derived === hand.detail.outcome,
+      derived: { outcome: derived },
+      expected: { outcome: hand.detail.outcome },
+    };
+  }
+
+  if (hand.game === 'hilo') {
+    const card = await deriveCard(serverSeed, clientSeed, nonce);
+    const expected = hand.detail.to;
+    return {
+      matches: card.rank === expected.rank && card.suit === expected.suit,
+      derived: { card: cardFromObj(card) },
+      expected: { card: cardFromObj(expected) },
+    };
+  }
+
+  if (hand.game === 'acey') {
+    const [m] = await deriveCards(serverSeed, clientSeed, nonce, 1);
+    const expected = hand.detail.middle;
+    return {
+      matches: m.rank === expected.rank && m.suit === expected.suit,
+      derived: { middle: cardFromObj(m) },
+      expected: { middle: cardFromObj(expected) },
+    };
+  }
+
+  if (hand.game === 'holdem') {
+    const deckIdx = await deriveDeck(serverSeed, clientSeed, nonce);
+    // Map idx -> 'rs' string the same way HoldEm did
+    const RANKS = ['2','3','4','5','6','7','8','9','T','J','Q','K','A'];
+    const PF_SUITS = ['s', 'h', 'd', 'c'];
+    const derivedDeck = deckIdx.map((idx) => RANKS[idx % 13] + PF_SUITS[Math.floor(idx / 13)]);
+    const expectedDeck = hand.detail.deck || [];
+    const matches = derivedDeck.length === expectedDeck.length &&
+      derivedDeck.every((c, i) => c === expectedDeck[i]);
+    return {
+      matches,
+      derived: { deck: derivedDeck },
+      expected: { deck: expectedDeck },
+    };
+  }
+
+  return { matches: false, reason: `unknown game type: ${hand.game}` };
+}
+
 function VerifyHandPage() {
+  const { id } = useParams();
+  const allHands = useMemo(loadHands, []);
+  const hand = useMemo(() => id ? getHand(id) : (allHands[0] || null), [id, allHands]);
+
+  const [commitmentOk, setCommitmentOk] = useState(null);
+  const [verification, setVerification] = useState({ status: 'idle' });
+
+  // Run on mount: check commitment + re-derive outcome
+  useEffect(() => {
+    if (!hand || !hand.pf) return;
+    let cancelled = false;
+    (async () => {
+      if (hand.pf.serverSeed && hand.pf.commitment) {
+        const ok = await verifyCommitment(hand.pf.serverSeed, hand.pf.commitment);
+        if (!cancelled) setCommitmentOk(ok);
+      } else {
+        if (!cancelled) setCommitmentOk(null);
+      }
+      setVerification({ status: 'pending' });
+      try {
+        const result = await rederiveHand(hand);
+        if (!cancelled) setVerification({ status: 'done', ...result });
+      } catch (e) {
+        if (!cancelled) setVerification({ status: 'error', error: e.message });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [hand]);
+
+  if (!hand) {
+    return (
+      <>
+        <Navigation />
+        <div className="ss-page">
+          <h1 className="ss-h1">Verify a hand</h1>
+          <p className="ss-sub">
+            No hand selected. <Link to="/history" style={{ color: 'var(--ss-gold)' }}>Pick one from history</Link> or
+            play a round to generate one.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  const { pf } = hand;
+  const verifyVerdict = verification.status === 'done' ? verification.matches : null;
+
   return (
     <>
       <Navigation />
       <div className="ss-page">
-        <div style={{ fontSize: 12, color: 'var(--ss-text-muted)', marginBottom: 12, letterSpacing: '0.04em' }}>
-          History / Table #4 · High Tide / Hand 142 / Verify
+        <div style={{ fontSize: 12, color: 'var(--ss-text-muted)', marginBottom: 8, letterSpacing: '0.04em' }}>
+          <Link to="/history" style={{ color: 'var(--ss-text-muted)' }}>History</Link>
+          {' / '}{GAME_LABELS[hand.game] || hand.game}{' / '}Hand #{hand.id} / Verify
         </div>
-        <h1 className="ss-h1">Verify Hand #142 · provably fair</h1>
+        <h1 className="ss-h1">Verify Hand #{hand.id} · provably fair</h1>
         <p className="ss-sub" style={{ maxWidth: 780 }}>
-          Every shuffle on Social Stakes is seeded by the hash of a Bitcoin block we hadn't seen yet
-          when bets were placed. You can re-run the deal yourself: anyone who agrees on the block hash
-          and the client-side nonces will arrive at the same deck. No backdoor, no possible house edge.
+          Every outcome on Social Stakes is the SHA-256 hash of a server seed (committed before any bets),
+          a client seed, and a per-hand nonce. Re-running the same inputs here must yield the same outcome —
+          or the deal was tampered with.
         </p>
 
-        <div className="ss-pill ss-pill-green" style={{ marginBottom: 28 }}>
-          ✓ Deal verified · shuffle matches published seed
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 20 }}>
+          <Verdict ok={commitmentOk} pendingLabel="Commitment unrevealed (rotate seed in the game to reveal)"
+            okLabel="✓ Commitment matches revealed seed"
+            badLabel="✗ Commitment does NOT match — tampered" />
+          <Verdict ok={verifyVerdict} pendingLabel={verification.status === 'pending' ? 'Re-deriving…' : 'Awaiting reveal'}
+            okLabel="✓ Outcome reproduces from seeds"
+            badLabel="✗ Outcome does not match" testId="verify-result-pill" />
         </div>
 
         <div className="ss-side-grid" style={{ marginBottom: 18 }}>
           <Section number="01" title="Seed inputs">
-            <KV k="Bitcoin block" v={<span className="ss-mono">932,481</span>} />
-            <KV k="Block hash" v={<span className="ss-mono" style={{ color: 'var(--ss-gold)', fontSize: 11, wordBreak: 'break-all' }}>
-              000000000000000000023f4c8a91d2e7b4a90fc3e0a8d61c2f5b9a73e88
-            </span>} />
-            <KV k="Block time" v={<span className="ss-mono">2026-05-12 14:33:18 UTC</span>} />
-            <KV k="Server nonce" v={<span className="ss-mono">srv-2026-05-12-9f3a</span>} />
-            <KV k="Client nonces" v={<span style={{ color: 'var(--ss-text-dim)' }}>6 players · combined sha256</span>} />
+            <KV k="Game" v={GAME_LABELS[hand.game] || hand.game} />
+            <KV k="Stake" v={<span className="ss-mono">${hand.stake}</span>} />
+            <KV k="Result" v={
+              <span style={{ color: hand.delta > 0 ? 'var(--ss-green)' : hand.delta < 0 ? 'var(--ss-red)' : 'var(--ss-text-dim)' }}>
+                {hand.result} ({hand.delta > 0 ? '+' : ''}${hand.delta})
+              </span>
+            } />
+            <KV k="Recorded" v={new Date(hand.ts).toLocaleString()} />
+            <KV k="Commitment" v={
+              <span className="ss-mono" style={{ color: 'var(--ss-gold)', fontSize: 11, wordBreak: 'break-all' }} data-testid="verify-commitment">
+                {pf?.commitment || '—'}
+              </span>
+            } />
+            <KV k="Server seed" v={
+              pf?.serverSeed ? (
+                <span className="ss-mono" style={{ fontSize: 11, color: 'var(--ss-text-dim)', wordBreak: 'break-all' }} data-testid="verify-server-seed">
+                  {pf.serverSeed}
+                </span>
+              ) : <span style={{ color: 'var(--ss-text-muted)' }}>not yet revealed</span>
+            } />
+            <KV k="Client seed" v={<span className="ss-mono" style={{ fontSize: 11 }}>{pf?.clientSeed}</span>} />
+            <KV k="Nonce" v={<span className="ss-mono">{pf?.nonce}</span>} />
           </Section>
 
-          <Section number="02" title="Combined seed">
-            <div style={{ background: 'var(--ss-bg)', border: '1px solid var(--ss-border-soft)', borderRadius: 10, padding: 14 }}>
-              <div className="ss-mono" style={{ color: 'var(--ss-gold)', fontSize: 13, lineHeight: 1.5, wordBreak: 'break-all' }}>
-                f3a91e2c7b48d5e0a91c<br />
-                4d8b3f7e2901c4a6b9f8<br />
-                e5d2c0741f9a6b3e8d52<br />
-                0291e7c4ab8d6f3e9012
-              </div>
-            </div>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12, fontSize: 12 }}>
-              <span style={{ color: 'var(--ss-text-muted)' }} className="ss-mono">
-                sha256( block_hash · srv_nonce · client_nonces )
-              </span>
-              <button className="ss-btn" style={{ height: 28, fontSize: 12 }}>Copy</button>
-            </div>
+          <Section number="02" title="Re-derive">
+            <p style={{ fontSize: 13, color: 'var(--ss-text-dim)', marginTop: 0, lineHeight: 1.5 }}>
+              We pipe <code className="ss-mono">serverSeed:clientSeed:nonce</code> into SHA-256 (chained),
+              then map the byte stream to game outcomes. Everything below was computed live in your browser.
+            </p>
+            <DerivationDetail hand={hand} verification={verification} />
           </Section>
         </div>
 
         <div className="ss-card" style={{ padding: 22, marginBottom: 18 }}>
-          <NumberLabel n="03" title="Hash chain" />
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 12, marginTop: 14, alignItems: 'center' }}>
-            <ChainStep label="Block" value={<span className="ss-mono">000…23f4c8a9</span>} />
-            <Arrow />
-            <ChainStep label="Server nonce" value={<span className="ss-mono">srv-2026-05-12-9f3a</span>} />
-            <Arrow />
-            <ChainStep label="Players" value={<span style={{ color: 'var(--ss-text-dim)' }}>6 nonces · merged</span>} />
-          </div>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 12, marginTop: 14, alignItems: 'center' }}>
-            <ChainStep label="Seed" value={<span className="ss-mono" style={{ color: 'var(--ss-gold)' }}>f3a91e2c…0291e7c4</span>} />
-            <Arrow />
-            <ChainStep label="Deck order" value={<span style={{ color: 'var(--ss-text-dim)' }}>52 cards (below)</span>} />
-            <div />
-            <div />
-          </div>
+          <NumberLabel n="03" title="What this proves" />
+          <ul style={{ marginTop: 12, marginBottom: 0, paddingLeft: 18, color: 'var(--ss-text-dim)', fontSize: 13, lineHeight: 1.7 }}>
+            <li><strong style={{ color: 'var(--ss-text)' }}>Commitment</strong> — SHA-256 of the server seed was published before any bet. If the revealed seed hashes to the same commitment, the seed wasn't swapped after the fact.</li>
+            <li><strong style={{ color: 'var(--ss-text)' }}>Re-derivation</strong> — Given the seed, anyone can recompute the same deck/flip/draw. Outcomes can't be invented by the house.</li>
+            <li><strong style={{ color: 'var(--ss-text)' }}>Nonce</strong> — Ties this specific hand to its slot in the seed chain. Without the nonce you can't tell which bet a card belonged to.</li>
+          </ul>
         </div>
 
         <div className="ss-card" style={{ padding: 22 }}>
-          <NumberLabel n="04" title="Deck order (top → bottom)" />
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(13, 1fr)', gap: 6, marginTop: 16 }}>
-            {SAMPLE_DECK.slice(0, 52).map((c, i) => (
-              <div key={i} style={{
-                aspectRatio: '0.72', borderRadius: 6,
-                background: i < 12 ? 'rgba(255,255,255,0.04)' : '#fafaf6',
-                border: '1px solid rgba(0,0,0,0.06)',
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                fontWeight: 700, fontSize: 13,
-                color: i < 12 ? 'var(--ss-text-dim)' : (SUITS_RED.some(s => c.includes(s)) ? '#d63a3a' : '#111'),
-                opacity: i < 12 ? 0.6 : 1,
-              }}>
-                {c}
-              </div>
-            ))}
-          </div>
+          <NumberLabel n="04" title="Reproduce externally" />
+          <p style={{ fontSize: 13, color: 'var(--ss-text-dim)', marginTop: 10 }}>
+            You don't have to trust this page. Copy the inputs and re-run in any environment:
+          </p>
+          <pre className="ss-mono" style={{
+            background: 'var(--ss-bg)', padding: 14, borderRadius: 8,
+            border: '1px solid var(--ss-border-soft)', fontSize: 12, overflow: 'auto', marginTop: 8,
+          }}>
+{`# Node.js
+const crypto = require('crypto');
+const h = crypto.createHash('sha256')
+  .update('${pf?.serverSeed || '<server seed>'}:${pf?.clientSeed}:${pf?.nonce}:0')
+  .digest('hex');
+console.log(h);   // first 8 bytes → first uint32 of the stream`}
+          </pre>
+          <CommitmentReproduction pf={pf} />
         </div>
       </div>
     </>
+  );
+}
+
+function Verdict({ ok, pendingLabel, okLabel, badLabel, testId }) {
+  const cls = ok === true ? 'ss-pill-green' : ok === false ? 'ss-pill-red' : '';
+  const label = ok === true ? okLabel : ok === false ? badLabel : pendingLabel;
+  return (
+    <span className={`ss-pill ${cls}`} style={{ fontSize: 12 }} data-testid={testId}>
+      {label}
+    </span>
+  );
+}
+
+function DerivationDetail({ hand, verification }) {
+  if (verification.status !== 'done') {
+    return <div style={{ fontSize: 12, color: 'var(--ss-text-muted)' }}>{verification.reason || 'Re-deriving…'}</div>;
+  }
+  if (verification.reason) {
+    return <div style={{ fontSize: 12, color: 'var(--ss-text-muted)' }}>{verification.reason}</div>;
+  }
+
+  if (hand.game === 'coinflip') {
+    return (
+      <KV k="Derived flip" v={
+        <span className="ss-mono" style={{ color: verification.matches ? 'var(--ss-green)' : 'var(--ss-red)' }}>
+          {verification.derived.outcome.toUpperCase()} (called {hand.detail.call.toUpperCase()})
+        </span>
+      } />
+    );
+  }
+
+  if (hand.game === 'hilo') {
+    return (
+      <>
+        <KV k="From card" v={<span className="ss-mono">{cardFromObj(hand.detail.from)}</span>} />
+        <KV k="Derived next" v={
+          <span className="ss-mono" style={{ color: verification.matches ? 'var(--ss-green)' : 'var(--ss-red)' }}>
+            {verification.derived.card}
+          </span>
+        } />
+        <KV k="Called" v={hand.detail.direction} />
+      </>
+    );
+  }
+
+  if (hand.game === 'acey') {
+    return (
+      <>
+        <KV k="Posts" v={
+          <span className="ss-mono">
+            {cardFromObj(hand.detail.posts[0])} _ {cardFromObj(hand.detail.posts[1])}
+          </span>
+        } />
+        <KV k="Derived middle" v={
+          <span className="ss-mono" style={{ color: verification.matches ? 'var(--ss-green)' : 'var(--ss-red)' }}>
+            {verification.derived.middle}
+          </span>
+        } />
+      </>
+    );
+  }
+
+  if (hand.game === 'holdem') {
+    const expected = verification.expected.deck;
+    const derived = verification.derived.deck;
+    return (
+      <>
+        <KV k="Player hole" v={
+          <span className="ss-mono">{hand.detail.playerHole?.map(holdemCardLabel).join(' ')}</span>
+        } />
+        <KV k="Bot hole" v={
+          <span className="ss-mono">{hand.detail.botHole?.map(holdemCardLabel).join(' ')}</span>
+        } />
+        {hand.detail.community?.length > 0 && (
+          <KV k="Community" v={
+            <span className="ss-mono">{hand.detail.community.map(holdemCardLabel).join(' ')}</span>
+          } />
+        )}
+        <KV k="Deck match" v={
+          <span style={{ color: verification.matches ? 'var(--ss-green)' : 'var(--ss-red)' }}>
+            {verification.matches ? `✓ all 52 cards match (${derived.length}/${expected.length})` : '✗ deck mismatch'}
+          </span>
+        } />
+        <div style={{ marginTop: 8 }}>
+          <div className="ss-stat-label" style={{ marginBottom: 6 }}>Derived deck (top → bottom)</div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(13, 1fr)', gap: 4 }}>
+            {derived.slice(0, 52).map((c, i) => (
+              <div key={i} className="ss-mono" style={{
+                padding: '4px 0', textAlign: 'center', fontSize: 11,
+                background: i < 4 ? 'rgba(199,158,82,0.15)' : 'rgba(255,255,255,0.04)',
+                borderRadius: 4,
+              }}>{holdemCardLabel(c)}</div>
+            ))}
+          </div>
+          <div style={{ fontSize: 10, color: 'var(--ss-text-muted)', marginTop: 6 }}>
+            (highlighted cards were dealt to the players & community)
+          </div>
+        </div>
+      </>
+    );
+  }
+
+  return null;
+}
+
+function CommitmentReproduction({ pf }) {
+  const [computed, setComputed] = useState(null);
+  useEffect(() => {
+    if (!pf?.serverSeed) return;
+    sha256Hex(pf.serverSeed).then(setComputed);
+  }, [pf?.serverSeed]);
+
+  if (!pf?.serverSeed) return null;
+
+  const ok = computed && computed === pf.commitment;
+  return (
+    <div style={{ marginTop: 14, fontSize: 12 }}>
+      <div className="ss-stat-label" style={{ marginBottom: 6 }}>SHA-256 of revealed seed (computed live)</div>
+      <div className="ss-mono" style={{ wordBreak: 'break-all', color: ok ? 'var(--ss-green)' : 'var(--ss-red)' }} data-testid="verify-recomputed-hash">
+        {computed || '…'}
+      </div>
+      <div style={{ marginTop: 4, color: 'var(--ss-text-muted)' }}>
+        {ok ? '↑ matches the commitment shown above' : 'expected to match the commitment'}
+      </div>
+    </div>
   );
 }
 
@@ -140,19 +375,6 @@ function KV({ k, v }) {
       <div>{v}</div>
     </div>
   );
-}
-
-function ChainStep({ label, value }) {
-  return (
-    <div>
-      <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.12em', color: 'var(--ss-text-muted)', marginBottom: 6 }}>{label}</div>
-      <div style={{ fontSize: 13 }}>{value}</div>
-    </div>
-  );
-}
-
-function Arrow() {
-  return <div style={{ color: 'var(--ss-gold)', textAlign: 'center', fontSize: 20 }}>→</div>;
 }
 
 export default VerifyHandPage;

--- a/frontend/src/components/games/AceyDuecey.js
+++ b/frontend/src/components/games/AceyDuecey.js
@@ -1,12 +1,16 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import Navigation from '../Navigation';
+import ProvablyFairPanel, { useProvablyFairSession } from '../ProvablyFairPanel';
+import { deriveCards, consumeNonce } from '../../utils/provablyFair';
+import { recordHand } from '../../utils/historyStore';
 
 const SUITS = ['♠', '♥', '♦', '♣'];
 const RANK_LABELS = { 1: 'A', 11: 'J', 12: 'Q', 13: 'K' };
 const rankLabel = (r) => RANK_LABELS[r] || String(r);
 
-function drawCard() {
-  return { rank: 1 + Math.floor(Math.random() * 13), suit: SUITS[Math.floor(Math.random() * 4)] };
+function randomCard() {
+  return { rank: 1 + Math.floor(Math.random() * 13), suit: Math.floor(Math.random() * 4) };
 }
 
 function CardArt({ card }) {
@@ -18,7 +22,8 @@ function CardArt({ card }) {
       }} />
     );
   }
-  const isRed = card.suit === '♥' || card.suit === '♦';
+  const suitSym = SUITS[card.suit];
+  const isRed = suitSym === '♥' || suitSym === '♦';
   return (
     <div style={{
       width: 90, height: 130, borderRadius: 10, background: '#fafaf6',
@@ -26,26 +31,31 @@ function CardArt({ card }) {
       position: 'relative', padding: 10,
       color: isRed ? '#d63a3a' : '#111', fontWeight: 800,
     }}>
-      <div style={{ fontSize: 16 }}>{rankLabel(card.rank)}{card.suit}</div>
-      <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', fontSize: 34 }}>{card.suit}</div>
-      <div style={{ position: 'absolute', bottom: 10, right: 10, fontSize: 16, transform: 'rotate(180deg)' }}>{rankLabel(card.rank)}{card.suit}</div>
+      <div style={{ fontSize: 16 }}>{rankLabel(card.rank)}{suitSym}</div>
+      <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', fontSize: 34 }}>{suitSym}</div>
+      <div style={{ position: 'absolute', bottom: 10, right: 10, fontSize: 16, transform: 'rotate(180deg)' }}>{rankLabel(card.rank)}{suitSym}</div>
     </div>
   );
 }
 
+function cardLabel(c) {
+  return `${rankLabel(c.rank)}${SUITS[c.suit]}`;
+}
+
 /**
- * Acey-Duecey (also called "In Between"): two cards are dealt face up.
+ * Acey-Duecey (also called "In Between"): two posts are dealt face up.
  * Player bets that a third card's rank will fall strictly between them.
- * Hitting one of the post cards is a "post" loss (we treat as -2x bet
- * to keep the math interesting). Tie-spread (both cards equal) ends the
- * round; player can match or pass.
+ * Hitting one of the posts pays -2x. The two post cards are random
+ * preview state; only the third (middle) card is derived from the seed.
  */
 function AceyDuecey() {
+  const { session, revealed, refresh, rotate } = useProvablyFairSession();
   const [bankroll, setBankroll] = useState(1000);
   const [bet, setBet] = useState(25);
-  const [cards, setCards] = useState(() => [drawCard(), drawCard()]);
+  const [cards, setCards] = useState(() => [randomCard(), randomCard()]);
   const [middle, setMiddle] = useState(null);
   const [result, setResult] = useState(null);
+  const [lastHandId, setLastHandId] = useState(null);
 
   const [low, high] = (() => {
     const a = cards[0].rank, b = cards[1].rank;
@@ -56,100 +66,131 @@ function AceyDuecey() {
   const newRound = () => {
     setMiddle(null);
     setResult(null);
-    setCards([drawCard(), drawCard()]);
+    setCards([randomCard(), randomCard()]);
   };
 
-  const play = (action) => {
-    if (bet > bankroll || bet <= 0) return;
-    if (action === 'pass') {
-      newRound();
-      return;
-    }
-    const m = drawCard();
+  const play = async (action) => {
+    if (action === 'pass') { newRound(); return; }
+    if (!session || bet > bankroll || bet <= 0) return;
+
+    const advanced = consumeNonce();
+    const [m] = await deriveCards(session.serverSeed, session.clientSeed, advanced.nonce, 1);
+    refresh(advanced);
     setMiddle(m);
+
     let delta;
     let outcome;
+    let resultCode;
     if (m.rank === cards[0].rank || m.rank === cards[1].rank) {
       delta = -2 * bet;
       outcome = 'Post! Penalty.';
+      resultCode = 'LOSE';
     } else if (m.rank > low && m.rank < high) {
       delta = bet;
       outcome = 'Between — you win.';
+      resultCode = 'WIN';
     } else {
       delta = -bet;
       outcome = 'Outside — you lose.';
+      resultCode = 'LOSE';
     }
-    setBankroll(b => b + delta);
+    setBankroll((b) => b + delta);
     setResult({ outcome, delta });
+
+    const record = recordHand({
+      game: 'acey',
+      stake: bet,
+      delta,
+      result: resultCode,
+      summary: `${cardLabel(cards[0])} _ ${cardLabel(cards[1])} → ${cardLabel(m)}`,
+      detail: { posts: cards, middle: m, outcome },
+      pf: {
+        commitment: session.commitment,
+        serverSeed: session.serverSeed,
+        clientSeed: session.clientSeed,
+        nonce: advanced.nonce,
+      },
+    });
+    setLastHandId(record.id);
   };
 
   return (
     <>
       <Navigation />
       <div className="ss-page">
-        <div className="ss-pill ss-pill-gold" style={{ marginBottom: 12 }}>Demo grade · Math.random()</div>
+        <div className="ss-pill ss-pill-green" style={{ marginBottom: 12 }}>Provably fair · SHA-256 commit-reveal</div>
         <h1 className="ss-h1">Acey-Duecey</h1>
         <p className="ss-sub">Bet that the third card falls strictly between the two posts. Match a post and pay double.</p>
 
-        <div className="ss-card" style={{ padding: 28, maxWidth: 760, margin: '0 auto' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
-            <div>
-              <div className="ss-stat-label">Bankroll</div>
-              <div className="ss-stat-value">${bankroll.toLocaleString()}</div>
+        <div className="ss-side-grid">
+          <div className="ss-card" style={{ padding: 28 }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+              <div>
+                <div className="ss-stat-label">Bankroll</div>
+                <div className="ss-stat-value">${bankroll.toLocaleString()}</div>
+              </div>
+              <div>
+                <div className="ss-stat-label">Spread</div>
+                <div className="ss-stat-value">{spread > 0 ? spread : '—'}</div>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span className="ss-stat-label" style={{ margin: 0 }}>Bet</span>
+                <input
+                  type="number"
+                  value={bet}
+                  onChange={(e) => setBet(Math.max(1, parseInt(e.target.value) || 0))}
+                  className="ss-mono"
+                  style={{
+                    width: 90, padding: '6px 10px', borderRadius: 8,
+                    background: 'var(--ss-bg-soft)', border: '1px solid var(--ss-border)',
+                    color: 'var(--ss-text)', fontSize: 14,
+                  }}
+                />
+              </div>
             </div>
-            <div>
-              <div className="ss-stat-label">Spread</div>
-              <div className="ss-stat-value">{spread > 0 ? spread : '—'}</div>
+
+            <div style={{ display: 'flex', gap: 18, justifyContent: 'center', alignItems: 'center', marginBottom: 24, minHeight: 160 }}>
+              <CardArt card={cards[0]} />
+              <CardArt card={middle} />
+              <CardArt card={cards[1]} />
             </div>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <span className="ss-stat-label" style={{ margin: 0 }}>Bet</span>
-              <input
-                type="number"
-                value={bet}
-                onChange={(e) => setBet(Math.max(1, parseInt(e.target.value) || 0))}
-                className="ss-mono"
-                style={{
-                  width: 90, padding: '6px 10px', borderRadius: 8,
-                  background: 'var(--ss-bg-soft)', border: '1px solid var(--ss-border)',
-                  color: 'var(--ss-text)', fontSize: 14,
-                }}
-              />
+
+            <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
+              <button
+                className="ss-btn ss-btn-primary"
+                onClick={() => play('bet')}
+                disabled={!!middle || bet > bankroll || spread <= 0}
+                style={{ minWidth: 140, height: 44, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase' }}
+              >
+                Deal middle
+              </button>
+              <button
+                className="ss-btn"
+                onClick={() => play('pass')}
+                style={{ minWidth: 140, height: 44, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase' }}
+              >
+                {middle ? 'Next round' : 'Pass'}
+              </button>
             </div>
+
+            {result && (
+              <div style={{
+                marginTop: 18, textAlign: 'center',
+                color: result.delta > 0 ? 'var(--ss-green)' : 'var(--ss-red)',
+                fontWeight: 600,
+              }}>
+                {result.outcome} {result.delta > 0 ? '+' : ''}${result.delta}
+                {lastHandId && (
+                  <>
+                    {' · '}
+                    <Link to={`/verify/${lastHandId}`} style={{ color: 'var(--ss-gold)', fontSize: 12 }}>verify ✓</Link>
+                  </>
+                )}
+              </div>
+            )}
           </div>
 
-          <div style={{ display: 'flex', gap: 18, justifyContent: 'center', alignItems: 'center', marginBottom: 24, minHeight: 160 }}>
-            <CardArt card={cards[0]} />
-            <CardArt card={middle} />
-            <CardArt card={cards[1]} />
-          </div>
-
-          <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
-            <button
-              className="ss-btn ss-btn-primary"
-              onClick={() => play('bet')}
-              disabled={!!middle || bet > bankroll || spread <= 0}
-              style={{ minWidth: 140, height: 44, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase' }}
-            >
-              Deal middle
-            </button>
-            <button
-              className="ss-btn"
-              onClick={() => play('pass')}
-              style={{ minWidth: 140, height: 44, fontSize: 14, letterSpacing: '0.08em', textTransform: 'uppercase' }}
-            >
-              {middle ? 'Next round' : 'Pass'}
-            </button>
-          </div>
-
-          {result && (
-            <div style={{
-              marginTop: 18, textAlign: 'center',
-              color: result.delta > 0 ? 'var(--ss-green)' : 'var(--ss-red)',
-              fontWeight: 600,
-            }}>
-              {result.outcome} {result.delta > 0 ? '+' : ''}${result.delta}
-            </div>
-          )}
+          <ProvablyFairPanel session={session} revealed={revealed} onRotate={rotate} />
         </div>
       </div>
     </>

--- a/frontend/src/components/games/CoinFlip.js
+++ b/frontend/src/components/games/CoinFlip.js
@@ -1,31 +1,53 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import Navigation from '../Navigation';
+import ProvablyFairPanel, { useProvablyFairSession } from '../ProvablyFairPanel';
+import { deriveCoinFlip, consumeNonce } from '../../utils/provablyFair';
+import { recordHand } from '../../utils/historyStore';
 
 /**
- * Single-player coin flip. Demo grade — uses Math.random(), not the
- * provably-fair Bitcoin-hash RNG that the blackjack server uses.
- * Tracked locally in component state; balance does not persist.
+ * Single-player coin flip. Deterministic outcome derived from a
+ * SHA-256 commit-reveal seed chain; each completed flip is logged to
+ * /history with full seeds so the user can re-derive it on /verify.
  */
 function CoinFlip() {
+  const { session, revealed, refresh, rotate } = useProvablyFairSession();
   const [bankroll, setBankroll] = useState(1000);
   const [bet, setBet] = useState(25);
-  const [picked, setPicked] = useState(null);
   const [result, setResult] = useState(null);
   const [history, setHistory] = useState([]);
   const [flipping, setFlipping] = useState(false);
 
-  const flip = (call) => {
-    if (flipping || bet <= 0 || bet > bankroll) return;
-    setPicked(call);
+  const flip = async (call) => {
+    if (flipping || bet <= 0 || bet > bankroll || !session) return;
     setResult(null);
     setFlipping(true);
+
+    const next = consumeNonce();
+    const outcome = await deriveCoinFlip(session.serverSeed, session.clientSeed, next.nonce);
+    refresh(next);
+
     setTimeout(() => {
-      const outcome = Math.random() < 0.5 ? 'heads' : 'tails';
       const won = outcome === call;
       const delta = won ? bet : -bet;
-      setBankroll(b => b + delta);
-      setResult({ outcome, won, delta });
-      setHistory(h => [{ call, outcome, delta }, ...h].slice(0, 12));
+      setBankroll((b) => b + delta);
+      const summary = `${call} → ${outcome}`;
+      const record = recordHand({
+        game: 'coinflip',
+        stake: bet,
+        delta,
+        result: won ? 'WIN' : 'LOSE',
+        summary,
+        detail: { call, outcome },
+        pf: {
+          commitment: session.commitment,
+          serverSeed: session.serverSeed,
+          clientSeed: session.clientSeed,
+          nonce: next.nonce,
+        },
+      });
+      setResult({ outcome, won, delta, handId: record.id });
+      setHistory((h) => [{ ...record, call, outcome }, ...h].slice(0, 12));
       setFlipping(false);
     }, 800);
   };
@@ -34,7 +56,7 @@ function CoinFlip() {
     <>
       <Navigation />
       <div className="ss-page">
-        <div className="ss-pill ss-pill-gold" style={{ marginBottom: 12 }}>Demo grade · Math.random()</div>
+        <div className="ss-pill ss-pill-green" style={{ marginBottom: 12 }}>Provably fair · SHA-256 commit-reveal</div>
         <h1 className="ss-h1">Coin Flip</h1>
         <p className="ss-sub">Call heads or tails. 50/50 odds, no house edge in this demo.</p>
 
@@ -106,28 +128,36 @@ function CoinFlip() {
                 fontWeight: 600,
               }}>
                 {result.outcome.toUpperCase()} — {result.won ? `Won $${result.delta}` : `Lost $${-result.delta}`}
+                {' · '}
+                <Link to={`/verify/${result.handId}`} style={{ color: 'var(--ss-gold)', fontSize: 12 }}>verify ✓</Link>
               </div>
             )}
           </div>
 
-          <div className="ss-card">
-            <div className="ss-stat-label" style={{ marginBottom: 12 }}>Recent flips</div>
-            {history.length === 0 ? (
-              <div style={{ color: 'var(--ss-text-muted)', fontSize: 13 }}>No flips yet.</div>
-            ) : (
-              history.map((h, i) => (
-                <div key={i} style={{
-                  display: 'flex', justifyContent: 'space-between',
-                  padding: '8px 0', borderBottom: '1px solid var(--ss-border-soft)',
-                  fontSize: 13,
-                }}>
-                  <span style={{ color: 'var(--ss-text-muted)' }}>{h.call} → <span style={{ color: 'var(--ss-text)' }}>{h.outcome}</span></span>
-                  <span style={{ color: h.delta > 0 ? 'var(--ss-green)' : 'var(--ss-red)', fontWeight: 600 }} className="ss-mono">
-                    {h.delta > 0 ? '+' : ''}${h.delta}
-                  </span>
-                </div>
-              ))
-            )}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <ProvablyFairPanel session={session} revealed={revealed} onRotate={rotate} />
+
+            <div className="ss-card">
+              <div className="ss-stat-label" style={{ marginBottom: 12 }}>Recent flips</div>
+              {history.length === 0 ? (
+                <div style={{ color: 'var(--ss-text-muted)', fontSize: 13 }}>No flips yet.</div>
+              ) : (
+                history.map((h, i) => (
+                  <div key={h.id} style={{
+                    display: 'flex', justifyContent: 'space-between',
+                    padding: '8px 0', borderBottom: '1px solid var(--ss-border-soft)',
+                    fontSize: 13,
+                  }}>
+                    <span style={{ color: 'var(--ss-text-muted)' }}>
+                      {h.call} → <span style={{ color: 'var(--ss-text)' }}>{h.outcome}</span>
+                    </span>
+                    <span style={{ color: h.delta > 0 ? 'var(--ss-green)' : 'var(--ss-red)', fontWeight: 600 }} className="ss-mono">
+                      {h.delta > 0 ? '+' : ''}${h.delta}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/games/HiLo.js
+++ b/frontend/src/components/games/HiLo.js
@@ -1,14 +1,20 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import Navigation from '../Navigation';
+import ProvablyFairPanel, { useProvablyFairSession } from '../ProvablyFairPanel';
+import { deriveCard, consumeNonce } from '../../utils/provablyFair';
+import { recordHand } from '../../utils/historyStore';
 
 const SUITS = ['♠', '♥', '♦', '♣'];
 const RANK_LABELS = { 1: 'A', 11: 'J', 12: 'Q', 13: 'K' };
 const rankLabel = (r) => RANK_LABELS[r] || String(r);
 
-function drawCard() {
-  const rank = 1 + Math.floor(Math.random() * 13);
-  const suit = SUITS[Math.floor(Math.random() * 4)];
-  return { rank, suit };
+function randomCard() {
+  return { rank: 1 + Math.floor(Math.random() * 13), suit: Math.floor(Math.random() * 4) };
+}
+
+function cardLabel(c) {
+  return `${rankLabel(c.rank)}${SUITS[c.suit]}`;
 }
 
 function CardArt({ card, big }) {
@@ -21,7 +27,8 @@ function CardArt({ card, big }) {
       }} />
     );
   }
-  const isRed = card.suit === '♥' || card.suit === '♦';
+  const suitSym = SUITS[card.suit];
+  const isRed = suitSym === '♥' || suitSym === '♦';
   return (
     <div style={{
       width: big ? 110 : 70, height: big ? 160 : 100,
@@ -31,35 +38,57 @@ function CardArt({ card, big }) {
       color: isRed ? '#d63a3a' : '#111',
       fontWeight: 800,
     }}>
-      <div style={{ fontSize: big ? 18 : 13 }}>{rankLabel(card.rank)}{card.suit}</div>
-      <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', fontSize: big ? 42 : 28 }}>{card.suit}</div>
-      <div style={{ position: 'absolute', bottom: 10, right: 10, fontSize: big ? 18 : 13, transform: 'rotate(180deg)' }}>{rankLabel(card.rank)}{card.suit}</div>
+      <div style={{ fontSize: big ? 18 : 13 }}>{rankLabel(card.rank)}{suitSym}</div>
+      <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%,-50%)', fontSize: big ? 42 : 28 }}>{suitSym}</div>
+      <div style={{ position: 'absolute', bottom: 10, right: 10, fontSize: big ? 18 : 13, transform: 'rotate(180deg)' }}>{rankLabel(card.rank)}{suitSym}</div>
     </div>
   );
 }
 
 function HiLo() {
+  const { session, revealed, refresh, rotate } = useProvablyFairSession();
   const [bankroll, setBankroll] = useState(1000);
   const [bet, setBet] = useState(25);
-  const [current, setCurrent] = useState(drawCard());
+  const [current, setCurrent] = useState(randomCard());
   const [next, setNext] = useState(null);
   const [streak, setStreak] = useState(0);
   const [history, setHistory] = useState([]);
+  const [lastHandId, setLastHandId] = useState(null);
 
-  const guess = (direction) => {
-    if (bet > bankroll || bet <= 0) return;
-    const n = drawCard();
+  const guess = async (direction) => {
+    if (!session || bet > bankroll || bet <= 0 || next) return;
+
+    const advanced = consumeNonce();
+    const n = await deriveCard(session.serverSeed, session.clientSeed, advanced.nonce);
+    refresh(advanced);
     setNext(n);
+
     let won;
-    if (n.rank === current.rank) won = false;          // tie loses
+    if (n.rank === current.rank) won = false;
     else if (direction === 'higher') won = n.rank > current.rank;
     else won = n.rank < current.rank;
 
     const delta = won ? bet : -bet;
     const newStreak = won ? streak + 1 : 0;
-    setBankroll(b => b + delta);
+    setBankroll((b) => b + delta);
     setStreak(newStreak);
-    setHistory(h => [{ from: current, to: n, direction, delta }, ...h].slice(0, 10));
+
+    const record = recordHand({
+      game: 'hilo',
+      stake: bet,
+      delta,
+      result: won ? 'WIN' : 'LOSE',
+      summary: `${cardLabel(current)} ${direction === 'higher' ? '↑' : '↓'} ${cardLabel(n)}`,
+      detail: { from: current, to: n, direction },
+      pf: {
+        commitment: session.commitment,
+        serverSeed: session.serverSeed,
+        clientSeed: session.clientSeed,
+        nonce: advanced.nonce,
+      },
+    });
+    setLastHandId(record.id);
+    setHistory((h) => [{ ...record, from: current, to: n, direction }, ...h].slice(0, 10));
 
     setTimeout(() => {
       setCurrent(n);
@@ -71,7 +100,7 @@ function HiLo() {
     <>
       <Navigation />
       <div className="ss-page">
-        <div className="ss-pill ss-pill-gold" style={{ marginBottom: 12 }}>Demo grade · Math.random()</div>
+        <div className="ss-pill ss-pill-green" style={{ marginBottom: 12 }}>Provably fair · SHA-256 commit-reveal</div>
         <h1 className="ss-h1">Hi-Lo</h1>
         <p className="ss-sub">Will the next card be higher or lower? Ties lose. Even-money payout.</p>
 
@@ -132,28 +161,38 @@ function HiLo() {
                 ↓ Lower
               </button>
             </div>
+
+            {lastHandId && (
+              <div style={{ textAlign: 'center', marginTop: 14, fontSize: 12 }}>
+                <Link to={`/verify/${lastHandId}`} style={{ color: 'var(--ss-gold)' }}>verify last hand ✓</Link>
+              </div>
+            )}
           </div>
 
-          <div className="ss-card">
-            <div className="ss-stat-label" style={{ marginBottom: 12 }}>Recent hands</div>
-            {history.length === 0 ? (
-              <div style={{ color: 'var(--ss-text-muted)', fontSize: 13 }}>No hands yet.</div>
-            ) : (
-              history.map((h, i) => (
-                <div key={i} style={{
-                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                  padding: '8px 0', borderBottom: '1px solid var(--ss-border-soft)',
-                  fontSize: 13,
-                }}>
-                  <span className="ss-mono" style={{ color: 'var(--ss-text-muted)' }}>
-                    {rankLabel(h.from.rank)}{h.from.suit} {h.direction === 'higher' ? '↑' : '↓'} {rankLabel(h.to.rank)}{h.to.suit}
-                  </span>
-                  <span style={{ color: h.delta > 0 ? 'var(--ss-green)' : 'var(--ss-red)', fontWeight: 600 }} className="ss-mono">
-                    {h.delta > 0 ? '+' : ''}${h.delta}
-                  </span>
-                </div>
-              ))
-            )}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            <ProvablyFairPanel session={session} revealed={revealed} onRotate={rotate} />
+
+            <div className="ss-card">
+              <div className="ss-stat-label" style={{ marginBottom: 12 }}>Recent hands</div>
+              {history.length === 0 ? (
+                <div style={{ color: 'var(--ss-text-muted)', fontSize: 13 }}>No hands yet.</div>
+              ) : (
+                history.map((h) => (
+                  <div key={h.id} style={{
+                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                    padding: '8px 0', borderBottom: '1px solid var(--ss-border-soft)',
+                    fontSize: 13,
+                  }}>
+                    <span className="ss-mono" style={{ color: 'var(--ss-text-muted)' }}>
+                      {cardLabel(h.from)} {h.direction === 'higher' ? '↑' : '↓'} {cardLabel(h.to)}
+                    </span>
+                    <span style={{ color: h.delta > 0 ? 'var(--ss-green)' : 'var(--ss-red)', fontWeight: 600 }} className="ss-mono">
+                      {h.delta > 0 ? '+' : ''}${h.delta}
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/games/HoldEm.js
+++ b/frontend/src/components/games/HoldEm.js
@@ -1,26 +1,26 @@
 import React, { useState, useRef, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { Hand } from 'pokersolver';
 import Navigation from '../Navigation';
+import ProvablyFairPanel, { useProvablyFairSession } from '../ProvablyFairPanel';
+import { deriveDeck, consumeNonce } from '../../utils/provablyFair';
+import { recordHand } from '../../utils/historyStore';
+
+// Map a 0..51 deck index to the 'rs' string format pokersolver expects.
+// Order: rank-major (rank 0..12 × suit 0..3). Suit order matches our
+// provablyFair derivation (0=♠,1=♥,2=♦,3=♣).
+const PF_SUITS = ['s', 'h', 'd', 'c'];
+function deckIdxToCard(idx) {
+  const rank = RANKS[idx % 13];
+  const suit = PF_SUITS[Math.floor(idx / 13)];
+  return rank + suit;
+}
 
 // ── deck primitives ──────────────────────────────────────────────
-const SUITS  = ['h', 'd', 'c', 's'];
 const RANKS  = ['2','3','4','5','6','7','8','9','T','J','Q','K','A'];
 const SUIT_SYM  = { h:'♥', d:'♦', c:'♣', s:'♠' };
 const RANK_DISP = { T:'10' };
 
-function makeDeck() {
-  const d = [];
-  for (const r of RANKS) for (const s of SUITS) d.push(r + s);
-  return d;
-}
-function shuffle(d) {
-  const a = [...d];
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
-}
 function rankIdx(c) { return RANKS.indexOf(c[0]); }
 
 // ── hand-strength helpers ─────────────────────────────────────────
@@ -109,6 +109,7 @@ function nextPhase(p) {
 
 // ── component ────────────────────────────────────────────────────
 export default function HoldEm() {
+  const { session, revealed, refresh, rotate } = useProvablyFairSession();
   const [bankroll,  setBankroll]  = useState(1000);
   const [ante,      setAnte]      = useState(25);
   const [streetBet, setStreetBet] = useState(25);
@@ -125,6 +126,8 @@ export default function HoldEm() {
   const [history,   setHistory]   = useState([]);
 
   const investedRef = useRef(0);
+  const handCtxRef  = useRef(null); // { nonce, deck } for the active hand
+  const [lastHandId, setLastHandId] = useState(null);
 
   // live hand hint for player after flop
   const playerHandHint = useMemo(() => {
@@ -136,9 +139,13 @@ export default function HoldEm() {
   }, [community, playerHole]);
 
   // ── game logic ─────────────────────────────────────────────────
-  const deal = () => {
-    if (ante <= 0 || ante > bankroll) return;
-    const d = shuffle(makeDeck());
+  const deal = async () => {
+    if (ante <= 0 || ante > bankroll || !session) return;
+    const advanced = consumeNonce();
+    const deckIdx = await deriveDeck(session.serverSeed, session.clientSeed, advanced.nonce);
+    refresh(advanced);
+    const d = deckIdx.map(deckIdxToCard);
+    handCtxRef.current = { nonce: advanced.nonce, deck: d };
     investedRef.current = ante;
     setBankroll(b => b - ante);
     setPot(ante * 2);
@@ -173,6 +180,35 @@ export default function HoldEm() {
     }
     setResult({ winner, delta, playerHand: phName, botHand: bhName });
     setHistory(h => [{ winner, delta, playerHand: phName, botHand: bhName }, ...h].slice(0, 10));
+
+    const ctx = handCtxRef.current;
+    if (ctx && session) {
+      const summary = winner === 'player' ? `Won · ${phName || 'bot folded'}`
+        : winner === 'bot' ? `Lost · ${bhName || 'folded'}`
+        : `Tie · ${phName}`;
+      const rec = recordHand({
+        game: 'holdem',
+        stake: invested,
+        delta,
+        result: winner === 'player' ? 'WIN' : winner === 'bot' ? 'LOSE' : 'PUSH',
+        summary,
+        detail: {
+          playerHole, botHole,
+          community: community.length ? community : undefined,
+          deck: ctx.deck, // full ordered deck for verification
+          winner,
+          playerHand: phName, botHand: bhName,
+        },
+        pf: {
+          commitment: session.commitment,
+          serverSeed: session.serverSeed,
+          clientSeed: session.clientSeed,
+          nonce: ctx.nonce,
+        },
+      });
+      setLastHandId(rec.id);
+    }
+
     setMessage(msg);
     setPhase('end');
   };
@@ -266,7 +302,7 @@ export default function HoldEm() {
     <>
       <Navigation />
       <div className="ss-page">
-        <div className="ss-pill ss-pill-gold" style={{ marginBottom: 10 }}>Demo grade · Math.random()</div>
+        <div className="ss-pill ss-pill-green" style={{ marginBottom: 10 }}>Provably fair · SHA-256 commit-reveal</div>
         <h1 className="ss-h1">Texas Hold'em</h1>
         <p className="ss-sub">Heads-up vs the bot. Both ante in — best 5-of-7 at showdown wins.</p>
 
@@ -461,6 +497,16 @@ export default function HoldEm() {
 
           {/* ── sidebar ── */}
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <ProvablyFairPanel session={session} revealed={revealed} onRotate={rotate} />
+
+            {lastHandId && (
+              <div className="ss-card" style={{ padding: 12, fontSize: 12, textAlign: 'center' }}>
+                <Link to={`/verify/${lastHandId}`} style={{ color: 'var(--ss-gold)' }}>
+                  verify last hand ✓
+                </Link>
+              </div>
+            )}
+
             {/* history */}
             <div className="ss-card">
               <div className="ss-stat-label" style={{ marginBottom: 10 }}>Recent hands</div>

--- a/frontend/src/utils/historyStore.js
+++ b/frontend/src/utils/historyStore.js
@@ -1,0 +1,143 @@
+// Cross-game hand history, persisted to localStorage.
+// Every game records each completed wager via `recordHand`; HistoryPage
+// reads via `loadHands` and VerifyHandPage looks up a single record via
+// `getHand`.
+
+const KEY = 'ss_history_v1';
+const MAX = 500;
+
+function safeRead() {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function safeWrite(arr) {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(arr.slice(0, MAX)));
+  } catch {
+    // out of quota; silently drop
+  }
+}
+
+function nextId(arr) {
+  if (!arr.length) return 1;
+  return (arr[0]?.id || 0) + 1;
+}
+
+// hand: {
+//   game: 'coinflip' | 'hilo' | 'acey' | 'holdem',
+//   stake: number,        // amount wagered
+//   delta: number,        // profit/loss, signed
+//   result: 'WIN' | 'LOSE' | 'PUSH' | 'BLACKJACK',
+//   summary: string,      // short human-readable result
+//   detail: object,       // game-specific (cards, deck, etc.)
+//   pf: { commitment, serverSeed, clientSeed, nonce } | null,
+// }
+export function recordHand(hand) {
+  const arr = safeRead();
+  const record = {
+    id: nextId(arr),
+    ts: Date.now(),
+    ...hand,
+  };
+  arr.unshift(record);
+  safeWrite(arr);
+  return record;
+}
+
+export function loadHands() {
+  return safeRead();
+}
+
+export function getHand(id) {
+  const arr = safeRead();
+  return arr.find((h) => String(h.id) === String(id)) || null;
+}
+
+export function clearHistory() {
+  safeWrite([]);
+}
+
+// --- Filtering / aggregates -------------------------------------------------
+
+export function filterHands(hands, { game, outcome, fromTs, toTs } = {}) {
+  return hands.filter((h) => {
+    if (game && game !== 'all' && h.game !== game) return false;
+    if (outcome === 'wins' && h.delta <= 0) return false;
+    if (outcome === 'losses' && h.delta >= 0) return false;
+    if (outcome === 'pushes' && h.delta !== 0) return false;
+    if (fromTs && h.ts < fromTs) return false;
+    if (toTs && h.ts > toTs) return false;
+    return true;
+  });
+}
+
+export function aggregateHands(hands) {
+  const handsPlayed = hands.length;
+  const wagered = hands.reduce((s, h) => s + Math.abs(h.stake || 0), 0);
+  const netPL = hands.reduce((s, h) => s + (h.delta || 0), 0);
+  const wins = hands.filter((h) => h.delta > 0).length;
+  const winRate = handsPlayed ? (wins / handsPlayed) * 100 : 0;
+  const pls = hands.map((h) => h.delta || 0);
+  const biggestWin = pls.length ? Math.max(0, ...pls) : 0;
+  const biggestLoss = pls.length ? Math.min(0, ...pls) : 0;
+  return { handsPlayed, wagered, netPL, winRate, biggestWin, biggestLoss };
+}
+
+// --- CSV export -------------------------------------------------------------
+
+function csvEscape(v) {
+  if (v === null || v === undefined) return '';
+  const s = String(v);
+  if (/[",\n]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+export function handsToCsv(hands) {
+  const head = [
+    'id', 'timestamp', 'game', 'result', 'stake', 'delta',
+    'summary', 'commitment', 'serverSeed', 'clientSeed', 'nonce',
+  ];
+  const rows = hands.map((h) => [
+    h.id,
+    new Date(h.ts).toISOString(),
+    h.game,
+    h.result,
+    h.stake,
+    h.delta,
+    h.summary,
+    h.pf?.commitment || '',
+    h.pf?.serverSeed || '',
+    h.pf?.clientSeed || '',
+    h.pf?.nonce ?? '',
+  ].map(csvEscape).join(','));
+  return [head.join(','), ...rows].join('\n');
+}
+
+export function downloadCsv(hands, filename = 'social-stakes-history.csv') {
+  const csv = handsToCsv(hands);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+// --- Display helpers --------------------------------------------------------
+
+export const GAME_LABELS = {
+  coinflip: 'Coin Flip',
+  hilo: 'Hi-Lo',
+  acey: 'Acey-Duecey',
+  holdem: "Hold'em",
+};

--- a/frontend/src/utils/provablyFair.js
+++ b/frontend/src/utils/provablyFair.js
@@ -1,0 +1,165 @@
+// Provably-fair RNG, fully reproducible from (serverSeed, clientSeed, nonce).
+//
+// Scheme (commit-reveal):
+//   1. At session start we generate a 256-bit serverSeed and publish only
+//      its SHA-256 hash (the "commitment"). The user can copy it before
+//      placing any bets.
+//   2. Each round increments `nonce`. Outcomes are derived from
+//      HMAC-style chained hashes of (serverSeed | clientSeed | nonce | cursor).
+//   3. When the user starts a new session (or asks for a reveal) we expose
+//      the full serverSeed. Anyone can SHA-256 it and confirm it matches
+//      the original commitment — proof we couldn't change the seed
+//      after seeing bets.
+//
+// The implementation uses only the Web Crypto API (no deps).
+
+const enc = new TextEncoder();
+
+function bytesToHex(bytes) {
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i].toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+export async function sha256Hex(input) {
+  const data = typeof input === 'string' ? enc.encode(input) : input;
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+// Generate 32 cryptographically-random bytes, returned as hex.
+export function randomSeed() {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return bytesToHex(bytes);
+}
+
+// Produce a stream of 32-bit unsigned integers from the chained hash of
+// (serverSeed:clientSeed:nonce:cursor). Cursor advances every 8 bytes
+// of digest consumed — i.e. one SHA-256 call yields 8 uint32 outputs.
+async function* uint32Stream(serverSeed, clientSeed, nonce) {
+  let cursor = 0;
+  while (true) {
+    const hex = await sha256Hex(
+      `${serverSeed}:${clientSeed}:${nonce}:${cursor}`
+    );
+    // 8 four-byte words per digest
+    for (let i = 0; i < 8; i++) {
+      const slice = hex.slice(i * 8, i * 8 + 8);
+      yield parseInt(slice, 16) >>> 0;
+    }
+    cursor += 1;
+  }
+}
+
+// Float in [0, 1), drawn deterministically from the seed stream.
+async function nextFloat(stream) {
+  const { value } = await stream.next();
+  return value / 0x100000000;
+}
+
+// Integer in [0, n).
+async function nextInt(stream, n) {
+  if (n <= 0) return 0;
+  const f = await nextFloat(stream);
+  return Math.floor(f * n);
+}
+
+// --- Per-game derivations ----------------------------------------------------
+
+// Single uniform 32-bit int.
+export async function deriveUint32(serverSeed, clientSeed, nonce) {
+  const stream = uint32Stream(serverSeed, clientSeed, nonce);
+  const { value } = await stream.next();
+  return value;
+}
+
+// Coin flip: 'heads' or 'tails'.
+export async function deriveCoinFlip(serverSeed, clientSeed, nonce) {
+  const u = await deriveUint32(serverSeed, clientSeed, nonce);
+  return u % 2 === 0 ? 'heads' : 'tails';
+}
+
+// Single playing card 0..51. rank 1..13, suit 0..3 (0=♠,1=♥,2=♦,3=♣).
+export async function deriveCard(serverSeed, clientSeed, nonce) {
+  const stream = uint32Stream(serverSeed, clientSeed, nonce);
+  const idx = await nextInt(stream, 52);
+  return { rank: (idx % 13) + 1, suit: Math.floor(idx / 13), _idx: idx };
+}
+
+// Draw N independent cards from one nonce, advancing the cursor between them.
+export async function deriveCards(serverSeed, clientSeed, nonce, count) {
+  const stream = uint32Stream(serverSeed, clientSeed, nonce);
+  const out = [];
+  for (let i = 0; i < count; i++) {
+    const idx = await nextInt(stream, 52);
+    out.push({ rank: (idx % 13) + 1, suit: Math.floor(idx / 13), _idx: idx });
+  }
+  return out;
+}
+
+// Fisher-Yates shuffle of a 52-card deck, deterministic from seed.
+// Returns array of 52 indices (0..51) — the games decide how to render.
+export async function deriveDeck(serverSeed, clientSeed, nonce) {
+  const stream = uint32Stream(serverSeed, clientSeed, nonce);
+  const deck = Array.from({ length: 52 }, (_, i) => i);
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = await nextInt(stream, i + 1);
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+  return deck;
+}
+
+// --- Session storage --------------------------------------------------------
+
+// We persist the (committed-but-unrevealed) server seed for the current
+// session so the page can survive reloads without leaking the seed to
+// other tabs. The history record snapshots seeds at the moment of reveal.
+
+const SESSION_KEY = 'ss_pf_session_v1';
+
+export async function getOrCreateSession() {
+  try {
+    const raw = sessionStorage.getItem(SESSION_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed && parsed.serverSeed && parsed.commitment && parsed.clientSeed) {
+        return parsed;
+      }
+    }
+  } catch {}
+  return rotateSession();
+}
+
+export async function rotateSession(clientSeed) {
+  const serverSeed = randomSeed();
+  const newClient = clientSeed || randomSeed().slice(0, 16);
+  const commitment = await sha256Hex(serverSeed);
+  const session = {
+    serverSeed,
+    clientSeed: newClient,
+    commitment,
+    nonce: 0,
+    createdAt: Date.now(),
+  };
+  sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  return session;
+}
+
+export function consumeNonce() {
+  const raw = sessionStorage.getItem(SESSION_KEY);
+  if (!raw) return null;
+  const parsed = JSON.parse(raw);
+  parsed.nonce = (parsed.nonce || 0) + 1;
+  sessionStorage.setItem(SESSION_KEY, JSON.stringify(parsed));
+  return parsed;
+}
+
+// Used by VerifyHandPage to confirm a stored hash matches a revealed seed.
+export async function verifyCommitment(serverSeed, commitment) {
+  if (!serverSeed || !commitment) return false;
+  const h = await sha256Hex(serverSeed);
+  return h === commitment;
+}


### PR DESCRIPTION
## Summary

- utils/provablyFair.js: SHA-256 commit/reveal + deterministic Fisher-Yates shuffle.
- utils/historyStore.js: localStorage-backed cross-game hand log with filters, aggregates, CSV export.
- ProvablyFairPanel shared across all games.
- All four single-player games derive outcomes from the seed chain and record each completed hand.
- HistoryPage: real records, filter UI (game type, outcome, date range), CSV export, cumulative P/L chart.
- VerifyHandPage: re-derives the recorded outcome live in the browser.

## Test plan

- [x] Build succeeds
- [x] SHA-256 reproduces in Node
- [ ] Vercel preview: play each game, confirm history records and verify works
